### PR TITLE
Wait for operation in cloud provider

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -21,19 +21,19 @@ import (
 )
 
 type fakeServiceManager struct {
-	createdInstances map[string]*Instance
+	createdInstances map[string]*ServiceInstance
 }
 
 var _ Service = &fakeServiceManager{}
 
 func NewFakeService() (Service, error) {
 	return &fakeServiceManager{
-		createdInstances: map[string]*Instance{},
+		createdInstances: map[string]*ServiceInstance{},
 	}, nil
 }
 
-func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Instance) (*Instance, error) {
-	instance := &Instance{
+func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
+	instance := &ServiceInstance{
 		Project:  "test-project",
 		Location: "test-location",
 		Name:     obj.Name,
@@ -53,11 +53,11 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Inst
 	return instance, nil
 }
 
-func (manager *fakeServiceManager) DeleteInstance(ctx context.Context, obj *Instance) error {
+func (manager *fakeServiceManager) DeleteInstance(ctx context.Context, obj *ServiceInstance) error {
 	return nil
 }
 
-func (manager *fakeServiceManager) GetInstance(ctx context.Context, obj *Instance) (*Instance, error) {
+func (manager *fakeServiceManager) GetInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
 	instance, _ := manager.createdInstances[obj.Name]
 	return instance, nil
 }

--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -18,6 +18,8 @@ package file
 
 import (
 	"context"
+
+	"google.golang.org/api/googleapi"
 )
 
 type fakeServiceManager struct {
@@ -58,6 +60,15 @@ func (manager *fakeServiceManager) DeleteInstance(ctx context.Context, obj *Serv
 }
 
 func (manager *fakeServiceManager) GetInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
-	instance, _ := manager.createdInstances[obj.Name]
-	return instance, nil
+	instance, exists := manager.createdInstances[obj.Name]
+	if exists {
+		return instance, nil
+	}
+	return nil, &googleapi.Error{
+		Errors: []googleapi.ErrorItem{
+			{
+				Reason: "notFound",
+			},
+		},
+	}
 }

--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
 
-type Instance struct {
+type ServiceInstance struct {
 	Project  string
 	Name     string
 	Location string
@@ -53,9 +53,9 @@ type Network struct {
 }
 
 type Service interface {
-	CreateInstance(ctx context.Context, obj *Instance) (*Instance, error)
-	DeleteInstance(ctx context.Context, obj *Instance) error
-	GetInstance(ctx context.Context, obj *Instance) (*Instance, error)
+	CreateInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error)
+	DeleteInstance(ctx context.Context, obj *ServiceInstance) error
+	GetInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error)
 }
 
 type gcfsServiceManager struct {
@@ -91,7 +91,7 @@ func NewGCFSService(version string) (Service, error) {
 	}, nil
 }
 
-func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Instance) (*Instance, error) {
+func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
 	// TODO: add some labels to to tag this plugin
 	betaObj := &beta.Instance{
 		Tier: obj.Tier,
@@ -134,7 +134,7 @@ func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Inst
 	return instance, nil
 }
 
-func (manager *gcfsServiceManager) GetInstance(ctx context.Context, obj *Instance) (*Instance, error) {
+func (manager *gcfsServiceManager) GetInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
 	instance, err := manager.instancesService.Get(instanceURI(obj.Project, obj.Location, obj.Name)).Context(ctx).Do()
 	if err != nil && !isNotFoundErr(err) {
 		return nil, fmt.Errorf("GetInstance operation failed: %v", err)
@@ -155,12 +155,12 @@ func (manager *gcfsServiceManager) GetInstance(ctx context.Context, obj *Instanc
 	return nil, nil
 }
 
-func cloudInstanceToServiceInstance(instance *beta.Instance) (*Instance, error) {
+func cloudInstanceToServiceInstance(instance *beta.Instance) (*ServiceInstance, error) {
 	project, location, name, err := getInstanceNameFromURI(instance.Name)
 	if err != nil {
 		return nil, err
 	}
-	return &Instance{
+	return &ServiceInstance{
 		Project:  project,
 		Location: location,
 		Name:     name,
@@ -177,7 +177,7 @@ func cloudInstanceToServiceInstance(instance *beta.Instance) (*Instance, error) 
 	}, nil
 }
 
-func CompareInstances(a, b *Instance) error {
+func CompareInstances(a, b *ServiceInstance) error {
 	mismatches := []string{}
 	if strings.ToLower(a.Tier) != strings.ToLower(b.Tier) {
 		mismatches = append(mismatches, "tier")
@@ -198,7 +198,7 @@ func CompareInstances(a, b *Instance) error {
 	return nil
 }
 
-func (manager *gcfsServiceManager) DeleteInstance(ctx context.Context, obj *Instance) error {
+func (manager *gcfsServiceManager) DeleteInstance(ctx context.Context, obj *ServiceInstance) error {
 	instance, err := manager.GetInstance(ctx, obj)
 	if err != nil {
 		return err

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -10,13 +10,13 @@ import (
 func TestCompareInstances(t *testing.T) {
 	cases := []struct {
 		name               string
-		a                  *Instance
-		b                  *Instance
+		a                  *ServiceInstance
+		b                  *ServiceInstance
 		expectedMismatches []string
 	}{
 		{
 			name: "matches equal",
-			a: &Instance{
+			a: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -26,7 +26,7 @@ func TestCompareInstances(t *testing.T) {
 					Name: "networkName",
 				},
 			},
-			b: &Instance{
+			b: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -39,7 +39,7 @@ func TestCompareInstances(t *testing.T) {
 		},
 		{
 			name: "matches equal rounded capacity",
-			a: &Instance{
+			a: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -49,7 +49,7 @@ func TestCompareInstances(t *testing.T) {
 					Name: "networkName",
 				},
 			},
-			b: &Instance{
+			b: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -62,7 +62,7 @@ func TestCompareInstances(t *testing.T) {
 		},
 		{
 			name: "matches equal tier lowercase",
-			a: &Instance{
+			a: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -72,7 +72,7 @@ func TestCompareInstances(t *testing.T) {
 					Name: "networkName",
 				},
 			},
-			b: &Instance{
+			b: &ServiceInstance{
 				Tier: "TIER",
 				Volume: Volume{
 					Name:      "volName",
@@ -85,7 +85,7 @@ func TestCompareInstances(t *testing.T) {
 		},
 		{
 			name: "nothing matches",
-			a: &Instance{
+			a: &ServiceInstance{
 				Tier: "tier",
 				Volume: Volume{
 					Name:      "volName",
@@ -95,7 +95,7 @@ func TestCompareInstances(t *testing.T) {
 					Name: "networkName",
 				},
 			},
-			b: &Instance{
+			b: &ServiceInstance{
 				Tier: "tier2",
 				Volume: Volume{
 					Name:      "volName2",

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -133,3 +133,67 @@ func TestCompareInstances(t *testing.T) {
 		}
 	}
 }
+
+func TestGetInstanceNameFromURI(t *testing.T) {
+	cases := []struct {
+		name      string
+		uri       string
+		project   string
+		location  string
+		instance  string
+		expectErr bool
+	}{
+		{
+			name:     "good",
+			uri:      "projects/test-project1/locations/test-$location/instances/test-^instance",
+			project:  "test-project1",
+			location: "test-$location",
+			instance: "test-^instance",
+		},
+		{
+			name:      "bad prefix",
+			uri:       "badprojects/test-project/locations/test-location/instances/test-instance",
+			expectErr: true,
+		},
+		{
+			name:      "bad suffix",
+			uri:       "projects/test-project/locations/test-location/instances/test-instance/bad",
+			expectErr: true,
+		},
+		{
+			name:      "missing instance",
+			uri:       "projects/test-project/locations/test-location/instances/",
+			expectErr: true,
+		},
+		{
+			name:      "missing location",
+			uri:       "projects/test-project/locations//instances/test-instance",
+			expectErr: true,
+		},
+		{
+			name:      "missing project",
+			uri:       "projects//locations/test-location/instances/test-instance",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		project, location, instance, err := getInstanceNameFromURI(test.uri)
+		if err == nil && test.expectErr {
+			t.Errorf("test %v failed: got success", test.name)
+		}
+		if err != nil && !test.expectErr {
+			t.Errorf("test %v failed: got error: %v", test.name, err)
+		}
+
+		if project != test.project {
+			t.Errorf("test %v failed: got project %q, expected %q", test.name, project, test.project)
+		}
+		if location != test.location {
+			t.Errorf("test %v failed: got location %q, expected %q", test.name, location, test.location)
+		}
+		if instance != test.instance {
+			t.Errorf("test %v failed: got instance %q, expected %q", test.name, instance, test.instance)
+		}
+	}
+}

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -92,7 +92,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 
 	// Check if the instance already exists
 	filer, err := s.config.fileService.GetInstance(ctx, newFiler)
-	if err != nil {
+	if err != nil && !file.IsNotFoundErr(err) {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if filer != nil {
@@ -154,7 +154,7 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 
 	filer.Project = s.config.metaService.GetProject()
 	newFiler, err := s.config.fileService.GetInstance(ctx, filer)
-	if err != nil {
+	if err != nil && !file.IsNotFoundErr(err) {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if newFiler == nil {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -206,7 +206,7 @@ func getRequestCapacity(capRange *csi.CapacityRange) int64 {
 
 // generateNewFileInstance populates the GCFS Instance object using
 // CreateVolume parameters
-func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, params map[string]string) (*file.Instance, error) {
+func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, params map[string]string) (*file.ServiceInstance, error) {
 	// Set default parameters
 	tier := defaultTier
 	network := defaultNetwork
@@ -228,7 +228,7 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 			return nil, fmt.Errorf("invalid parameter %q", k)
 		}
 	}
-	return &file.Instance{
+	return &file.ServiceInstance{
 		Project:  s.config.metaService.GetProject(),
 		Name:     name,
 		Location: location,
@@ -245,7 +245,7 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 }
 
 // fileInstanceToCSIVolume generates a CSI volume spec from the cloud Instance
-func fileInstanceToCSIVolume(instance *file.Instance, mode string) *csi.Volume {
+func fileInstanceToCSIVolume(instance *file.ServiceInstance, mode string) *csi.Volume {
 	return &csi.Volume{
 		Id:            getVolumeIdFromFileInstance(instance, mode),
 		CapacityBytes: instance.Volume.SizeBytes,

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -293,12 +293,12 @@ func TestGenerateNewFileInstance(t *testing.T) {
 	cases := []struct {
 		name      string
 		params    map[string]string
-		instance  *file.Instance
+		instance  *file.ServiceInstance
 		expectErr bool
 	}{
 		{
 			name: "default params",
-			instance: &file.Instance{
+			instance: &file.ServiceInstance{
 				Project:  testProject,
 				Name:     testCSIVolume,
 				Location: testLocation,
@@ -321,7 +321,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 				"csiProvisionerSecretName":      "foo-secret",
 				"csiProvisionerSecretNamespace": "foo-namespace",
 			},
-			instance: &file.Instance{
+			instance: &file.ServiceInstance{
 				Project:  testProject,
 				Name:     testCSIVolume,
 				Location: "foo-location",

--- a/pkg/csi_driver/volume_id.go
+++ b/pkg/csi_driver/volume_id.go
@@ -36,7 +36,7 @@ const (
 
 // getVolumeIdFromFileInstance generates an id to uniquely identify the GCFS volume.
 // This id is used for volume deletion.
-func getVolumeIdFromFileInstance(obj *file.Instance, mode string) string {
+func getVolumeIdFromFileInstance(obj *file.ServiceInstance, mode string) string {
 	idElements := make([]string, totalIdElements)
 	idElements[idProvisioningMode] = mode
 	idElements[idLocation] = obj.Location
@@ -46,13 +46,13 @@ func getVolumeIdFromFileInstance(obj *file.Instance, mode string) string {
 }
 
 // getFileInstanceFromId generates a GCFS Instance object from the volume id
-func getFileInstanceFromId(id string) (*file.Instance, string, error) {
+func getFileInstanceFromId(id string) (*file.ServiceInstance, string, error) {
 	tokens := strings.Split(id, "/")
 	if len(tokens) != totalIdElements {
 		return nil, "", fmt.Errorf("volume id %q unexpected format: got %v tokens", id, len(tokens))
 	}
 
-	return &file.Instance{
+	return &file.ServiceInstance{
 		Location: tokens[idLocation],
 		Name:     tokens[idInstance],
 		Volume:   file.Volume{Name: tokens[idVolume]},


### PR DESCRIPTION
The Kubernetes external-provisioner timeout is currently too short for a create/delete operation to succeed in one call.  However, non-Kubernetes implementations may not have such a short timeout, so the cloud provider calls should try to wait for the operation to complete if able to.

Fixes #5 