### PR TITLE
Updating documentation and demo-sc to encorperate IP reservation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,18 @@ This plugin can be used beginning with Kubernetes v1.10.5
 This version of the driver creates a new Cloud Filestore instance per
 volume. Customizable parameters for volume creation include:
 
-| Parameter       | Values                  | Default    | Description |
-| --------------- | ----------------------- |----------- | ----------- |
-| tier            | "standard"<br>"premium" | "standard" | storage performance tier |
-| network         | string                  | "default"  | VPC name |
-| location        | string                  | zone where the plugin<br>is running in | zone |
+| Parameter         | Values                  | Default    | Description                                            										    |
+| ------------------| ----------------------- |----------- | ----------- ---------------------------------------------------------------------------------------------------------------------------										    |
+| tier              | "standard"<br>"premium" | "standard" | storage performance tier                               										    |
+| network           | string                  | "default"  | VPC name 																    |
+| location          | string                  | zone where the plugin<br>is running in | zone                       										    |
+| reserved-ipv4-cidr| string		      | ""         | CIDR range to allocate Filestore IP Ranges from. The CIDR must be large enough to accommodate multiple Filestore IP Ranges of /29 each |
 
 For Kubernetes clusters, these parameters are specified in the StorageClass.
 
 Note that non-default networks require extra [firewall setup](https://cloud.google.com/filestore/docs/configuring-firewall)
 
 ## Future Features
-* Reserved IP range: To avoid IP conflict issues, add a CreateVolume parameter
-  to provide an IP block that is reserved for dynamically provisioning GCFS instances.
 * Non-root access: By default, GCFS instances are only writable by the root user
   and readable by all users. Provide a CreateVolume parameter to set non-root
   owners.

--- a/examples/kubernetes/demo-sc.yaml
+++ b/examples/kubernetes/demo-sc.yaml
@@ -6,6 +6,8 @@ provisioner: com.google.csi.filestore
 parameters:
   # Available locations can be found at: TODO
   location: us-central1-c
+  # "CIDR range to allocate Filestore IP Ranges from"
+  # reserved-ipv4-cidr: 192.168.92.22/26
   # # standard (default) or premier
   # tier: premier
   # # Name of the VPC. Note that non-default VPCs require special firewall rules to be setup: TODO


### PR DESCRIPTION
This PR consists of documentation and example updates pertaining to the IP reservation functionality [changes](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/12/commits/eee9991e2c26f68d458f6268b556be73ccc508d0) 
