### PR TITLE
Typo on check for the clusterrolebinding

### DIFF
--- a/deploy/kubernetes/cluster_setup.sh
+++ b/deploy/kubernetes/cluster_setup.sh
@@ -9,7 +9,7 @@ mydir="$(dirname $0)"
 source "$mydir/../common.sh"
 
 # GKE requires this extra cluster-admin rolebinding in order to create clusterroles
-if ! kubectl get clusterrolebinding cluster-admin binding; then
+if ! kubectl get clusterrolebinding cluster-admin-binding; then
   kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
 fi
 


### PR DESCRIPTION
The check checks for `cluster-admin` and `binding`, but not `cluster-admin-binding`