### PR TITLE
Update Makefile with image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE=gcr.io/$(PROJECT)/gcp-filestore-csi-driver
+# Core Filestore CSI driver binary
+DRIVERBINARY=gcp-filestore-csi-driver
 
+# A space-separated list of image tags under which the current build is to be pushed.
+# Determined dynamically.
+STAGINGVERSION=
+ifdef GCP_FS_CSI_STAGING_VERSION
+	STAGINGVERSION=${GCP_FS_CSI_STAGING_VERSION}
+else
+	STAGINGVERSION=$(shell ./build/generate_image_tags.sh)
+endif
+$(info STAGINGVERSION is $(STAGINGVERSION))
+
+STAGINGIMAGE=
+ifdef GCP_FS_CSI_STAGING_IMAGE
+	STAGINGIMAGE=$(GCP_FS_CSI_STAGING_IMAGE)
+else
+	STAGINGIMAGE=gcr.io/$(PROJECT)/gcp-filestore-csi-driver
+endif
+$(info STAGINGIMAGE is $(STAGINGIMAGE))
+
+# This flag is used only for csi-client and windows.
+# TODO: Unify VERSION with STAGINGIMAGE
 ifeq ($(VERSION),)
 	VERSION=latest
 endif
 
 all: image
 
-image: 
-	docker build --build-arg TAG=$(VERSION) -t $(IMAGE):$(VERSION) .
+# Build the docker image for the core CSI driver.
+image:
+		{                                                                   \
+		set -e ;                                                            \
+		for i in $(STAGINGVERSION) ;                                        \
+			do docker build --build-arg DRIVERBINARY=$${DRIVERBINARY} -t $(STAGINGIMAGE):$${i} .; \
+		done ;                                                              \
+		}
 
-local:	
+# Build the go binary for the CSI driver.
+# STAGINGVERSION may contain multiple tags (e.g. canary, vX.Y.Z etc). Use one of the tags
+# for setting the driver version variable. For convenience we are using the first value.
+driver:
 	mkdir -p bin
-	go build -mod=vendor -ldflags "-X main.vendorVersion=${VERSION}" -o bin/gcfs-csi-driver ./cmd/
+	{                                                                                                                                 \
+	set -e ;                                                                                                                          \
+	for i in $(STAGINGVERSION) ; do                                                                                                   \
+		CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-X main.version='"$${i}"' -extldflags "-static"' -o bin/${DRIVERBINARY} ./cmd/; \
+		break;                                                                                                                          \
+	done ;                                                                                                                            \
+	}
 
 windows: windows-local
 	docker build -f test/experimental/Dockerfile --build-arg TAG=$(VERSION) -t $(IMAGE)-windows:$(VERSION) .
-	
+
 windows-local:
 	mkdir -p bin
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.vendorVersion=${VERSION}" -o bin/gcfs-csi-driver.exe ./cmd/
 
-push:
-	docker push $(IMAGE):$(VERSION)
+build-image-and-push: image
+	{                                       \
+	set -e ;                                \
+	for i in $(STAGINGVERSION) ;            \
+		do docker push $(STAGINGIMAGE):$${i}; \
+	done;                                   \
+	}
 
 skaffold-dev:
 	skaffold dev -f deploy/skaffold/skaffold.yaml

--- a/build/generate_image_tags.sh
+++ b/build/generate_image_tags.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A space-separated list of image tags under which the current build is to be pushed.
+# Determined dynamically.
+IMAGE_TAGS=
+
+# A "canary" image gets built if the current commit is the head of the remote "master" branch.
+if [ $(git rev-list -n1 HEAD) == $(git rev-list -n1 origin/master 2>/dev/null) ]; then
+  IMAGE_TAGS+="canary "
+fi
+
+# A release image "vX.Y.Z" gets built if there is a tag of that format for the current commit.
+# --abbrev=0 suppresses long format, only showing the closest tag.
+LATEST_GIT_TAG=$(git describe --tags --match='v*' --abbrev=0)
+HEAD_REV=$(git rev-list -n1 HEAD)
+
+# This variable stores the revision corresponding to the latest tag detected.
+LATEST_TAG_REV=
+if [ $LATEST_GIT_TAG ]; then
+  LATEST_TAG_REV=$(git rev-list -n1 $LATEST_GIT_TAG)
+fi
+
+if [ $LATEST_TAG_REV ] && [ $LATEST_TAG_REV == $HEAD_REV ]; then
+  IMAGE_TAGS+=$LATEST_TAG_REV
+  IMAGE_TAGS+=" "
+fi
+
+# TODO: Create "X.Y.Z-canary" TAG when release-X.Y.Z branch created
+
+# If we did not detect any IMAGE_TAGS, then use the latest git head
+# commit as the image tag.
+if [[ -z $IMAGE_TAGS ]]; then
+  IMAGE_TAGS+=$HEAD_REV
+fi
+
+echo $IMAGE_TAGS

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# A configuration file for multi-arch image building with the Google cloud build service.
+#
+# See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
+# for more details on image pushing process in Kubernetes.
+#
+# To promote release images, see https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp.
+
+# This must be specified in seconds. If omitted, defaults to 600s (10 mins).
+timeout: 1200s
+# This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  # The image must contain bash and curl. Ideally it should also contain
+  # the desired version of Go (currently defined in release-tools/travis.yml),
+  # but that just speeds up the build and is not required.
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200713-e9b3d9d'
+    entrypoint: make
+    env:
+    - GIT_TAG=${_GIT_TAG}
+    - PULL_BASE_REF=${_PULL_BASE_REF}
+    - PROJECT=${_STAGING_PROJECT}
+    args:
+    - build-image-and-push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution.
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'
+  # The default gcr.io staging project for GCP artifacts
+  # (=> https://console.cloud.google.com/gcr/images/k8s-staging-cloud-provider-gcp/GLOBAL).
+  _STAGING_PROJECT: 'k8s-staging-cloud-provider-gcp'


### PR DESCRIPTION
This patch makes changes to the makefile
1. Dynamically generate image tags
2. Update the image build and push rules for all tags.
3. Create a cloudbuild yaml to enable auto builds.

TODO:
Add a prow job based on the cloudbuild.yaml