### PR TITLE
Add resizer feature to Filestore driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Note that non-default networks require extra [firewall setup](https://cloud.goog
   [nfs-client](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client)
   external provisioner can be used to provide similar functionality for
   Kubernetes clusters.
-* Volume resizing: CSI Filestore driver does not support volume resizing yet, but Cloud Filestore
-  instances can currently be [manually resized](https://cloud.google.com/filestore/docs/editing-instances).
+* Volume resizing: CSI Filestore driver supports volume expansion for all supported Filestore tiers.
 * Topology preferences: For better performance, it is recommended to run
   workloads in the same zone where the Cloud Filestore instance is provisioned in. In the
   future, the location where to create a Cloud Filestore instance could be automatically

--- a/deploy/kubernetes/manifests/controller.yaml
+++ b/deploy/kubernetes/manifests/controller.yaml
@@ -27,6 +27,15 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-external-resizer
+          image: gcr.io/gke-release/csi-resizer:v0.5.0-gke.0
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--csiTimeout=120s"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: gcp-filestore-driver
           # Modify this image for local development with master branch.
           image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0

--- a/deploy/kubernetes/manifests/setup_cluster.yaml
+++ b/deploy/kubernetes/manifests/setup_cluster.yaml
@@ -61,4 +61,36 @@ roleRef:
   name: gcp-filestore-csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
 
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: gcp-filestore-csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---

--- a/examples/kubernetes/demo-sc.yaml
+++ b/examples/kubernetes/demo-sc.yaml
@@ -12,3 +12,4 @@ parameters:
   # tier: premier
   # # Name of the VPC. Note that non-default VPCs require special firewall rules to be setup: TODO
   # network: default
+allowVolumeExpansion: true

--- a/examples/kubernetes/sc-latebind.yaml
+++ b/examples/kubernetes/sc-latebind.yaml
@@ -6,3 +6,4 @@ provisioner: filestore.csi.storage.gke.io
 parameters:
   location: us-central1-c
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -18,6 +18,7 @@ package file
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/api/googleapi"
 )
@@ -95,4 +96,15 @@ func (manager *fakeServiceManager) ListInstances(ctx context.Context, obj *Servi
 		},
 	}
 	return instances, nil
+}
+
+func (manager *fakeServiceManager) ResizeInstance(ctx context.Context, obj *ServiceInstance) (*ServiceInstance, error) {
+	instance, ok := manager.createdInstances[obj.Name]
+	if !ok {
+		return nil, fmt.Errorf("Instance %v not found", obj.Name)
+	}
+
+	instance.Volume.SizeBytes = obj.Volume.SizeBytes
+	manager.createdInstances[obj.Name] = instance
+	return instance, nil
 }

--- a/pkg/csi_driver/controller_unimpl.go
+++ b/pkg/csi_driver/controller_unimpl.go
@@ -55,10 +55,6 @@ func (s *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnaps
 	return nil, status.Error(codes.Unimplemented, "ListSnapshots unsupported")
 }
 
-func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControllerExpandVolume unsupported")
-}
-
 func (s *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "ControllerExpandVolume unsupported")
 }

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -87,6 +87,7 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 	if config.RunController {
 		csc := []csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		}
 		driver.addControllerServiceCapabilities(csc)
 

--- a/pkg/csi_driver/identity.go
+++ b/pkg/csi_driver/identity.go
@@ -46,6 +46,20 @@ func (s *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.Get
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+					},
+				},
+			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/pkg/csi_driver/identity_test.go
+++ b/pkg/csi_driver/identity_test.go
@@ -65,7 +65,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 		t.Fatalf("GetPluginCapabilities resp is nil")
 	}
 
-	if len(resp.Capabilities) != 1 {
+	if len(resp.Capabilities) != 3 {
 		t.Fatalf("returned %v capabilities", len(resp.Capabilities))
 	}
 
@@ -80,6 +80,24 @@ func TestGetPluginCapabilities(t *testing.T) {
 
 	if serviceType := service.GetType(); serviceType != csi.PluginCapability_Service_CONTROLLER_SERVICE {
 		t.Fatalf("returned %v capability service", serviceType)
+	}
+
+	volumeexpansion := resp.Capabilities[1].GetVolumeExpansion()
+	if volumeexpansion == nil {
+		t.Fatalf("returned nil volume expansion capability")
+	}
+
+	if expansiontype := volumeexpansion.GetType(); expansiontype != csi.PluginCapability_VolumeExpansion_ONLINE {
+		t.Fatalf("returned %v capability", expansiontype)
+	}
+
+	volumeexpansion = resp.Capabilities[2].GetVolumeExpansion()
+	if volumeexpansion == nil {
+		t.Fatalf("returned nil volume expansion capability")
+	}
+
+	if expansiontype := volumeexpansion.GetType(); expansiontype != csi.PluginCapability_VolumeExpansion_OFFLINE {
+		t.Fatalf("returned %v capability", expansiontype)
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,10 @@ func RoundBytesToGb(bytes int64) int64 {
 	return (bytes + Gb - 1) / Gb
 }
 
+func BytesToGb(bytes int64) int64 {
+	return bytes / Gb
+}
+
 func GbToBytes(gbs int64) int64 {
 	return gbs * Gb
 }


### PR DESCRIPTION
1. add rbac rules and resizer sidecar
2. Add code for controller expand volume
3. updated exisitng unit tests

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Add support for Volume Expansion 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #54 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for Volume Expansion for Filestore CSI driver
```
