### PR TITLE
Topology feature support for Filestore CSI driver

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,10 +47,15 @@ func main() {
 	var err error
 	if *runController {
 		provider, err = cloud.NewCloud(version)
-		if err != nil {
-			glog.Fatalf("Failed to initialize cloud provider: %v", err)
-		}
+	} else {
+		// For driver running in worker nodes, initialize cloud provider with only medata service.
+		provider, err = cloud.NewCloudWithMetadataService()
 	}
+
+	if err != nil {
+		glog.Fatalf("Failed to initialize cloud provider: %v", err)
+	}
+
 	mounter := mount.New("")
 	config := &driver.GCFSDriverConfig{
 		Name:          driverName,

--- a/deploy/kubernetes/manifests/controller.yaml
+++ b/deploy/kubernetes/manifests/controller.yaml
@@ -24,6 +24,7 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--timeout=250s"
+            - "--feature-gates=Topology=true"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/examples/kubernetes/demo-sc.yaml
+++ b/examples/kubernetes/demo-sc.yaml
@@ -4,8 +4,6 @@ metadata:
   name: csi-filestore
 provisioner: filestore.csi.storage.gke.io
 parameters:
-  # Available locations can be found at: TODO
-  location: us-central1-c
   # "CIDR range to allocate Filestore IP Ranges from"
   # reserved-ipv4-cidr: 192.168.92.22/26
   # # standard (default) or premier

--- a/examples/kubernetes/sc-latebind.yaml
+++ b/examples/kubernetes/sc-latebind.yaml
@@ -3,7 +3,5 @@ kind: StorageClass
 metadata:
   name: csi-filestore
 provisioner: filestore.csi.storage.gke.io
-parameters:
-  location: us-central1-c
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/examples/kubernetes/topology/delayed-binding/demo-deployment-delayed-allowedtopo.yaml
+++ b/examples/kubernetes/topology/delayed-binding/demo-deployment-delayed-allowedtopo.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server-delayed-binding-allowedtopo
+  labels:
+    app: nginx
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: mypvc
+      volumes:
+      - name: mypvc
+        persistentVolumeClaim:
+          claimName: test-pvc-fs-delayed-binding-allowedtopo
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-pvc-fs-delayed-binding-allowedtopo
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: csi-filestore-delayed-binding-allowedtopo
+  resources:
+    requests:
+      storage: 1Ti

--- a/examples/kubernetes/topology/delayed-binding/sc-delayed-allowedtopo.yaml
+++ b/examples/kubernetes/topology/delayed-binding/sc-delayed-allowedtopo.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-filestore-delayed-binding-allowedtopo
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    # Replace the values with a subset of zones of the regional cluster
+    values:
+    - us-central1-a
+    - us-central1-b

--- a/examples/kubernetes/topology/immediate-binding/demo-deployment-immediate-allowedtopo.yaml
+++ b/examples/kubernetes/topology/immediate-binding/demo-deployment-immediate-allowedtopo.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server-immediate-allowedtopo
+  labels:
+    app: nginx
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: mypvc
+      nodeSelector:
+        topology.gke.io/zone: us-central1-a
+      volumes:
+      - name: mypvc
+        persistentVolumeClaim:
+          claimName: test-pvc-fs-immediate-binding-allowedtopo
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-pvc-fs-immediate-binding-allowedtopo
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: csi-filestore-immediate-binding-allowedtopo
+  resources:
+    requests:
+      storage: 1Ti

--- a/examples/kubernetes/topology/immediate-binding/sc-immediate-allowedtopo.yaml
+++ b/examples/kubernetes/topology/immediate-binding/sc-immediate-allowedtopo.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-filestore-immediate-binding-allowedtopo
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    values:
+    - us-central1-a

--- a/pkg/cloud_provider/cloud.go
+++ b/pkg/cloud_provider/cloud.go
@@ -43,3 +43,14 @@ func NewCloud(version string) (*Cloud, error) {
 		Meta: meta,
 	}, nil
 }
+
+func NewCloudWithMetadataService() (*Cloud, error) {
+	meta, err := metadata.NewMetadataService()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Metadata service: %v", err)
+	}
+
+	return &Cloud{
+		Meta: meta,
+	}, nil
+}

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/file"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
@@ -309,11 +310,12 @@ func TestGenerateNewFileInstance(t *testing.T) {
 	cases := []struct {
 		name      string
 		params    map[string]string
+		toporeq   *csi.TopologyRequirement
 		instance  *file.ServiceInstance
 		expectErr bool
 	}{
 		{
-			name: "default params",
+			name: "default params, nil topology requirement",
 			instance: &file.ServiceInstance{
 				Project:  testProject,
 				Name:     testCSIVolume,
@@ -329,10 +331,99 @@ func TestGenerateNewFileInstance(t *testing.T) {
 			},
 		},
 		{
-			name: "custom params",
+			name: "custom params, non-nil topology requirement",
+			toporeq: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+				},
+			},
 			params: map[string]string{
 				paramTier:                       "foo-tier",
-				paramLocation:                   "foo-location",
+				paramNetwork:                    "foo-network",
+				"csiProvisionerSecretName":      "foo-secret",
+				"csiProvisionerSecretNamespace": "foo-namespace",
+			},
+			instance: &file.ServiceInstance{
+				Project:  testProject,
+				Name:     testCSIVolume,
+				Location: "foo-location",
+				Tier:     "foo-tier",
+				Network: file.Network{
+					Name: "foo-network",
+				},
+				Volume: file.Volume{
+					Name:      newInstanceVolume,
+					SizeBytes: testBytes,
+				},
+			},
+		},
+		{
+			name: "custom params, preferred topology requirement",
+			toporeq: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "bar-location",
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "bar-location",
+						},
+					},
+				},
+			},
+			params: map[string]string{
+				paramTier:                       "foo-tier",
+				paramNetwork:                    "foo-network",
+				"csiProvisionerSecretName":      "foo-secret",
+				"csiProvisionerSecretNamespace": "foo-namespace",
+			},
+			instance: &file.ServiceInstance{
+				Project:  testProject,
+				Name:     testCSIVolume,
+				Location: "bar-location",
+				Tier:     "foo-tier",
+				Network: file.Network{
+					Name: "foo-network",
+				},
+				Volume: file.Volume{
+					Name:      newInstanceVolume,
+					SizeBytes: testBytes,
+				},
+			},
+		},
+		{
+			name: "custom params, requisite topology requirement only",
+			toporeq: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+				},
+			},
+			params: map[string]string{
+				paramTier:                       "foo-tier",
 				paramNetwork:                    "foo-network",
 				"csiProvisionerSecretName":      "foo-secret",
 				"csiProvisionerSecretNamespace": "foo-namespace",
@@ -367,7 +458,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 			t.Fatalf("couldn't get internal controller")
 		}
 
-		filer, err := internalServer.generateNewFileInstance(testCSIVolume, testBytes, test.params)
+		filer, err := internalServer.generateNewFileInstance(testCSIVolume, testBytes, test.params, test.toporeq)
 		if !test.expectErr && err != nil {
 			t.Errorf("test %q failed: %v", test.name, err)
 		}
@@ -377,5 +468,178 @@ func TestGenerateNewFileInstance(t *testing.T) {
 		if !reflect.DeepEqual(filer, test.instance) {
 			t.Errorf("test %q failed: got filer %+v, expected %+v", test.name, filer, test.instance)
 		}
+	}
+}
+
+func TestGetZoneFromSegment(t *testing.T) {
+	cases := []struct {
+		name         string
+		seg          map[string]string
+		expectErr    bool
+		expectedZone string
+	}{
+		// Error cases
+		{
+			name:      "Empty segment map",
+			seg:       make(map[string]string),
+			expectErr: true,
+		},
+		{
+			name: "Missing zone key in segment map",
+			seg: map[string]string{
+				"zonekey": "z1",
+			},
+			expectErr: true,
+		},
+		{
+			name: "Unknown zone key in segment map",
+			seg: map[string]string{
+				TopologyKeyZone: "z1",
+				"unknown_key":   "z2",
+			},
+			expectErr: true,
+		},
+		// Successful cases
+		{
+			name: "Found expected zone",
+			seg: map[string]string{
+				TopologyKeyZone: "z1",
+			},
+			expectedZone: "z1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			z, err := getZoneFromSegment(tc.seg)
+			if tc.expectErr && err == nil {
+				t.Errorf("Expected error, got none")
+			}
+
+			if !tc.expectErr && err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+
+			if z != tc.expectedZone {
+				t.Errorf("Unexpected zone %v, expected zone %v", z, tc.expectedZone)
+			}
+		})
+	}
+}
+
+func TestGetZonesFromTopology(t *testing.T) {
+	cases := []struct {
+		name          string
+		topo          []*csi.Topology
+		expectErr     bool
+		expectedZones []string
+	}{
+		// Error cases
+		{
+			name:          "nil topology list",
+			topo:          nil,
+			expectedZones: make([]string, 0),
+		},
+		{
+			name:          "Empty topology list",
+			topo:          make([]*csi.Topology, 0),
+			expectedZones: make([]string, 0),
+		},
+		{
+			name:      "Non-Empty topology list with missing segment",
+			topo:      make([]*csi.Topology, 1),
+			expectErr: true,
+		},
+		{
+			name: "Non-Empty topology list with segment missing zone key",
+			topo: []*csi.Topology{
+				{
+					Segments: map[string]string{},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Non-Empty topology list with segment unknown zone key",
+			topo: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"unknown_zone_key": "z1",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Non-Empty topology list with empty segment map",
+			topo: []*csi.Topology{
+				{
+					Segments: make(map[string]string),
+				},
+			},
+			expectErr: true,
+		},
+		// two elements, one with error.
+		{
+			name: "Non-Empty topology list with error in one of the elements",
+			topo: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"unknown_key": "z1",
+					},
+				},
+				{
+					Segments: map[string]string{
+						TopologyKeyZone: "z2",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		// Success cases
+		{
+			name: "Non-Empty topology list with valid segment",
+			topo: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						TopologyKeyZone: "z1",
+					},
+				},
+			},
+			expectedZones: []string{"z1"},
+		},
+		{
+			name: "Non-Empty topology list with multiple zones",
+			topo: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						TopologyKeyZone: "z1",
+					},
+				},
+				{
+					Segments: map[string]string{
+						TopologyKeyZone: "z2",
+					},
+				},
+			},
+			expectedZones: []string{"z1", "z2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			z, err := getZonesFromTopology(tc.topo)
+			if tc.expectErr && err == nil {
+				t.Errorf("Expected error, got none")
+			}
+
+			if !tc.expectErr && err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+
+			if !sets.NewString(z...).Equal(sets.NewString(tc.expectedZones...)) {
+				t.Errorf("Unexpected zone list %v, expected zone list %v", z, tc.expectedZones)
+			}
+		})
 	}
 }

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -82,7 +82,7 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 	// Setup RPC servers
 	driver.ids = newIdentityServer(driver)
 	if config.RunNode {
-		driver.ns = newNodeServer(driver, config.Mounter)
+		driver.ns = newNodeServer(driver, config.Mounter, config.Cloud.Meta)
 	}
 	if config.RunController {
 		csc := []csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi_driver/gcfs_driver_test.go
+++ b/pkg/csi_driver/gcfs_driver_test.go
@@ -20,14 +20,21 @@ import (
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	cloud "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider"
 )
 
 func initTestDriver(t *testing.T) *GCFSDriver {
+	c, err := cloud.NewFakeCloud()
+	if err != nil {
+		t.Fatalf("Failed to init cloud")
+	}
+
 	config := &GCFSDriverConfig{
 		Name:    "test-driver",
 		NodeID:  "test-node",
 		Version: "test-version",
 		RunNode: true,
+		Cloud:   c,
 	}
 	driver, err := NewGCFSDriver(config)
 	if err != nil {

--- a/pkg/csi_driver/identity.go
+++ b/pkg/csi_driver/identity.go
@@ -60,6 +60,13 @@ func (s *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.Get
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/pkg/csi_driver/identity_test.go
+++ b/pkg/csi_driver/identity_test.go
@@ -65,7 +65,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 		t.Fatalf("GetPluginCapabilities resp is nil")
 	}
 
-	if len(resp.Capabilities) != 3 {
+	if len(resp.Capabilities) != 4 {
 		t.Fatalf("returned %v capabilities", len(resp.Capabilities))
 	}
 
@@ -98,6 +98,15 @@ func TestGetPluginCapabilities(t *testing.T) {
 
 	if expansiontype := volumeexpansion.GetType(); expansiontype != csi.PluginCapability_VolumeExpansion_OFFLINE {
 		t.Fatalf("returned %v capability", expansiontype)
+	}
+
+	service = resp.Capabilities[3].GetService()
+	if service == nil {
+		t.Fatalf("returned nil capability service")
+	}
+
+	if serviceType := service.GetType(); serviceType != csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS {
+		t.Fatalf("returned %v capability service", serviceType)
 	}
 }
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -25,6 +25,7 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"k8s.io/utils/mount"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
 )
 
 var (
@@ -58,8 +59,12 @@ type nodeServerTestEnv struct {
 func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	// TODO: make a constructor in FakeMmounter library
 	mounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
+	metaserice, err := metadata.NewFakeService()
+	if err != nil {
+		t.Fatalf("Failed to init metadata service")
+	}
 	return &nodeServerTestEnv{
-		ns: newNodeServer(initTestDriver(t), mounter),
+		ns: newNodeServer(initTestDriver(t), mounter, metaserice),
 		fm: mounter,
 	}
 }


### PR DESCRIPTION
1. Support Topology constraints feature in FS CSI driver
2. Use Storage Class allowedTopology field to provide input to
   FS driver for instance creation.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This patch removes the need to 'location' parameter in storage class, and uses CreateVolumeRequest.accessibility_requirements  field to determine a zone for instance creation. Further the CreateVolume response does not put any restriction on the volume, since it can be accessed across all zones on the same VPC.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Topology feature support for Filestore CSI driver
```
