### PR TITLE
Support NodeStageVolume for the driver

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -47,7 +47,7 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Serv
 		},
 		Network: Network{
 			Name:            obj.Network.Name,
-			Ip:              "test-ip",
+			Ip:              "1.1.1.1",
 			ReservedIpRange: obj.Network.ReservedIpRange,
 		},
 		Labels: obj.Labels,

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -31,7 +31,7 @@ import (
 const (
 	testProject          = "test-project"
 	testLocation         = "test-location"
-	testIP               = "test-ip"
+	testIP               = "1.1.1.1"
 	testCSIVolume        = "test-csi"
 	testVolumeID         = "modeInstance/test-location/test-csi/vol1"
 	testReservedIPV4CIDR = "192.168.92.0/26"

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -82,7 +82,11 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 	// Setup RPC servers
 	driver.ids = newIdentityServer(driver)
 	if config.RunNode {
+		nscap := []csi.NodeServiceCapability_RPC_Type{
+			csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+		}
 		driver.ns = newNodeServer(driver, config.Mounter, config.Cloud.Meta)
+		driver.addNodeServiceCapabilities(nscap)
 	}
 	if config.RunController {
 		csc := []csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -106,6 +106,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		if mounted {
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
+		if os.IsNotExist(err) {
+			if mkdirErr := os.MkdirAll(targetPath, 0750); mkdirErr != nil {
+				return nil, status.Error(codes.Internal, fmt.Sprintf("mkdir failed on path %s (%v)", targetPath, mkdirErr))
+			}
+		}
 	}
 
 	if readOnly {

--- a/pkg/csi_driver/node_unimpl.go
+++ b/pkg/csi_driver/node_unimpl.go
@@ -23,14 +23,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "NodeStageVolume unsupported")
-}
-
-func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "NodeUnStageVolume unsupported")
-}
-
 func (s *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "NodeUnStageVolume unsupported")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #47

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support NodeStageVolume for Filestore CSI driver, and NodePublish should create the target path if missing.
```
