### PR TITLE
 create overlays for filestore driver

### DIFF
--- a/deploy/common.sh
+++ b/deploy/common.sh
@@ -3,8 +3,33 @@
 set -o nounset
 set -o errexit
 
-GCFS_SA_DIR="${GCFS_SA_DIR:-$HOME}"
-# If you override the file name, then kubernetes/controller.yaml must also be
+function ensure_var(){
+    if [[ -z "${!1:-}" ]];
+    then
+        echo "${1} is unset"
+        exit 1
+    else
+        echo "${1} is ${!1}"
+    fi
+}
+
+# Installs kustomize in ${PKGDIR}/bin
+function ensure_kustomize()
+{
+  ensure_var PKGDIR
+  "${PKGDIR}/deploy/kubernetes/install_kustomize.sh"
+}
+
+ensure_var GOPATH
+ensure_var PROJECT
+
+readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-filestore-csi-driver"
+readonly VERBOSITY="${GCE_FS_VERBOSITY:-2}"
+readonly KUSTOMIZE_PATH="${PKGDIR}/bin/kustomize"
+readonly KUBECTL="${GCP_FS_KUBECTL:-kubectl}"
+readonly GCFS_SA_DIR="${GCFS_SA_DIR:-$HOME}"
+
+# If you override the file name, then deploy/kubernetes/base/controller/controller.yaml must also be
 # updated
 GCFS_SA_FILE="$GCFS_SA_DIR/gcp_filestore_csi_driver_sa.json"
 GCFS_SA_NAME=gcp-filestore-csi-driver-sa

--- a/deploy/kubernetes/base/controller/controller.yaml
+++ b/deploy/kubernetes/base/controller/controller.yaml
@@ -1,0 +1,75 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-controller
+spec:
+  serviceName: "gcp-filestore-csi-driver"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gcp-filestore-csi-driver
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcp-filestore-csi-driver
+    spec:
+      serviceAccount: gcp-filestore-csi-controller-sa
+      containers:
+        - name: csi-external-provisioner
+          image: gcr.io/gke-release/csi-provisioner
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--timeout=250s"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-external-resizer
+          image: gcr.io/gke-release/csi-resizer
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--csiTimeout=120s"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-external-snapshotter
+          image: gcr.io/gke-release/csi-snapshotter
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--timeout=300s"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: gcp-filestore-driver
+          # Modify this image for local development with master branch.
+          image: gcr.io/gke-release/gcp-filestore-csi-driver
+          args:
+            - "--v=4"
+            - "--endpoint=unix:/csi/csi.sock"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--controller=true"
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/cloud_sa/gcp_filestore_csi_driver_sa.json"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: "/etc/cloud_sa"
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: cloud-sa-volume
+          secret:
+            secretName: gcp-filestore-csi-driver-sa

--- a/deploy/kubernetes/base/controller/csi_driver.yaml
+++ b/deploy/kubernetes/base/controller/csi_driver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: filestore.csi.storage.gke.io
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/deploy/kubernetes/base/controller/kustomization.yaml
+++ b/deploy/kubernetes/base/controller/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- setup_cluster.yaml
+- controller.yaml
+- csi_driver.yaml
+- psp.yaml

--- a/deploy/kubernetes/base/controller/psp.yaml
+++ b/deploy/kubernetes/base/controller/psp.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: gcp-filestore-csi-controller-psp
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - "emptyDir"
+    - "secret"
+  hostNetwork: true

--- a/deploy/kubernetes/base/controller/setup_cluster.yaml
+++ b/deploy/kubernetes/base/controller/setup_cluster.yaml
@@ -1,0 +1,183 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gcp-filestore-csi-driver
+---
+##### Node Service Account, Roles, RoleBindings
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-filestore-csi-node-sa
+  namespace: gcp-filestore-csi-driver
+---
+##### Controller Service Account, Roles, Rolebindings
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-filestore-csi-controller-sa
+  namespace: gcp-filestore-csi-driver
+---
+# xref: https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: gcp-filestore-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: gcp-filestore-csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-filestore-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: gcp-filestore-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-controller-deploy
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+      - gcp-filestore-csi-controller-psp
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-filestore-csi-controller-deploy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-filestore-csi-controller-deploy
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-node-deploy
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - gcp-filestore-csi-node-psp
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-filestore-csi-node-deploy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-filestore-csi-node-deploy
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-node-sa
+    namespace: gcp-filestore-csi-driver
+---

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- controller
+- node_linux

--- a/deploy/kubernetes/base/node_linux/kustomization.yaml
+++ b/deploy/kubernetes/base/node_linux/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- node.yaml
+- psp.yaml

--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -1,0 +1,73 @@
+#TODO: Force DaemonSet to not run on master.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-node
+spec:
+  selector:
+    matchLabels:
+      app: gcp-filestore-csi-driver
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcp-filestore-csi-driver
+    spec:
+      serviceAccount: gcp-filestore-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-driver-registrar
+          image: gcr.io/gke-release/csi-node-driver-registrar:v1.3.0-gke.0
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/filestore.csi.storage.gke.io/csi.sock"
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: gcp-filestore-driver
+          securityContext:
+            privileged: true
+          # Modify this image for local development with master branch.
+          image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0
+          args:
+            - "--v=5"
+            - "--endpoint=unix:/csi/csi.sock"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--node=true"
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+        - name: nfs-services
+          # Modify this image for local development with master branch.
+          image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0
+          command: ["/nfs_services_start.sh"]
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/filestore.csi.storage.gke.io/
+            type: DirectoryOrCreate

--- a/deploy/kubernetes/base/node_linux/psp.yaml
+++ b/deploy/kubernetes/base/node_linux/psp.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: gcp-filestore-csi-node-psp
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  volumes:
+  - '*'
+  hostNetwork: true
+  allowedHostPaths:
+  - pathPrefix: "/var/lib/kubelet/plugins_registry/"
+  - pathPrefix: "/var/lib/kubelet"
+  - pathPrefix: "/var/lib/kubelet/plugins/filestore.csi.storage.gke.io/"
+

--- a/deploy/kubernetes/cluster_cleanup.sh
+++ b/deploy/kubernetes/cluster_cleanup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
 mydir="$(dirname $0)"
-kubectl delete secret gcp-filestore-csi-driver-sa --namespace=$GCFS_NS
-kubectl delete -f "$mydir/manifests/setup_cluster.yaml"
+source "$mydir/../common.sh"
+
+${KUSTOMIZE_PATH} build "${PKGDIR}/deploy/kubernetes/overlays/${DEPLOY_VERSION}" | ${KUBECTL} delete -v="${VERBOSITY}" --ignore-not-found -f -
+${KUBECTL} delete secret gcp-filestore-csi-driver-sa -v="${VERBOSITY}" --ignore-not-found
+
+if [[ "${GCFS_NS}" != "default" ]] && \
+  ${KUBECTL} get namespace "${GCFS_NS}" -v="${VERBOSITY}";
+then
+    ${KUBECTL} delete namespace "${GCFS_NS}" -v="${VERBOSITY}"
+fi

--- a/deploy/kubernetes/cluster_setup.sh
+++ b/deploy/kubernetes/cluster_setup.sh
@@ -8,13 +8,26 @@ mydir="$(dirname $0)"
 
 source "$mydir/../common.sh"
 
+# DEPLOY_VERSION should point to the overlays name.
+ensure_var DEPLOY_VERSION
+ensure_kustomize
+
+if ! ${KUBECTL} get namespace "${GCFS_NS}" -v="${VERBOSITY}";
+then
+  ${KUBECTL} create namespace "${GCFS_NS}" -v="${VERBOSITY}"
+fi
+
 # GKE requires this extra cluster-admin rolebinding in order to create clusterroles
 if ! kubectl get clusterrolebinding cluster-admin-binding; then
   kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
 fi
 
-kubectl apply -f "$mydir/manifests/setup_cluster.yaml"
-
-if ! kubectl get secret gcp-filestore-csi-driver-sa --namespace=$GCFS_NS; then
-  kubectl create secret generic gcp-filestore-csi-driver-sa --from-file="$GCFS_SA_FILE" --namespace=$GCFS_NS
+if [ "${DEPLOY_VERSION}" != dev ]; then
+  if ! kubectl get secret gcp-filestore-csi-driver-sa --namespace=$GCFS_NS; then
+    kubectl create secret generic gcp-filestore-csi-driver-sa --from-file="$GCFS_SA_FILE" --namespace=$GCFS_NS
+  fi
 fi
+
+readonly tmp_spec=/tmp/gcp-filestore-csi-driver-specs-generated.yaml
+${KUSTOMIZE_PATH} build "${PKGDIR}/deploy/kubernetes/overlays/${DEPLOY_VERSION}" | tee $tmp_spec
+${KUBECTL} apply -v="${VERBOSITY}" -f $tmp_spec

--- a/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
@@ -1,0 +1,60 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-head
+imageTag:
+  name: gcr.io/gke-release/csi-provisioner
+  newName: quay.io/k8scsi/csi-provisioner
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-attacher-prow-head
+imageTag:
+  name: gcr.io/gke-release/csi-attacher
+  newName: quay.io/k8scsi/csi-provisioner
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-head
+imageTag:
+  name: gcr.io/gke-release/csi-resizer
+  newName: quay.io/k8scsi/csi-resizer
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-head
+imageTag:
+  name: gke.gcr.io/csi-snapshotter
+  newName: quay.io/k8scsi/csi-provisioner
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-gce-driver-prow-head
+imageTag:
+  name: gcr.io/gke-release/gcp-filestore-csi-driver
+  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
+  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-head
+imageTag:
+  name: gcr.io/gke-release/csi-node-driver-registrar
+  newName: quay.io/k8scsi/csi-node-driver-registrar
+  newTag: "canary"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-head/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
@@ -1,0 +1,60 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: gcr.io/gke-release/csi-provisioner
+  newName: gcr.io/gke-release-staging/csi-provisioner
+  newTag: "v1.6.0-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-attacher-prow-rc
+imageTag:
+  name: gcr.io/gke-release/csi-attacher
+  newName: gcr.io/gke-release-staging/csi-attacher
+  newTag: "v2.2.0-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: gcr.io/gke-release/csi-resizer
+  newName: gcr.io/gke-release-staging/csi-resizer
+  newTag: "v1.0.1-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-head
+imageTag:
+  name: gcr.io/gke-release/csi-snapshotter
+  newName: gcr.io/gke-release-staging/csi-snapshotter
+  newTag: "v2.1.1-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-gce-driver-prow-rc
+imageTag:
+  name: gcr.io/gke-release/gcp-filestore-csi-driver
+  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
+  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: gcr.io/gke-release/csi-node-driver-registrar
+  newName: gcr.io/gke-release-staging/csi-node-driver-registrar
+  newTag: "v1.3.0-gke.0"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable/image.yaml
+++ b/deploy/kubernetes/images/stable/image.yaml
@@ -1,0 +1,55 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner
+imageTag:
+  name: gcr.io/gke-release/csi-provisioner
+  newTag: "v1.6.0-gke.0"
+
+---
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-attacher
+imageTag:
+  name: gcr.io/gke-release/csi-attacher
+  newTag: "v2.2.0-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resizer
+imageTag:
+  name: gcr.io/gke-release/csi-resizer
+  newTag: "v0.5.0-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter
+imageTag:
+  name: gcr.io/gke-release/csi-snapshotter
+  newTag: "v2.1.1-gke.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gcpfs-driver
+imageTag:
+  name: gcr.io/gke-release/gcp-filestore-csi-driver
+  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
+  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar
+imageTag:
+  name: gcr.io/gke-release/csi-node-driver-registrar
+  newTag: "v1.3.0-gke.0"
+---

--- a/deploy/kubernetes/images/stable/kustomization.yaml
+++ b/deploy/kubernetes/images/stable/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/install_kustomize.sh
+++ b/deploy/kubernetes/install_kustomize.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script will install kustomize, which is a tool that simplifies patching
+# Kubernetes manifests for different environments.
+# https://github.com/kubernetes-sigs/kustomize
+
+set -o nounset
+set -o errexit
+
+readonly INSTALL_DIR="${GOPATH}/src/sigs.k8s.io/gcp-filestore-csi-driver/bin"
+readonly KUSTOMIZE_PATH="${INSTALL_DIR}/kustomize"
+
+if [ ! -f "${INSTALL_DIR}" ]; then
+  mkdir -p "${INSTALL_DIR}"
+fi
+if [ -f "kustomize" ]; then
+  rm kustomize
+fi
+
+echo "installing kustomize"
+
+where=$PWD
+if [ -f $where/kustomize ]; then
+  echo "A file named kustomize already exists (remove it first)."
+  exit 1
+fi
+
+tmpDir=`mktemp -d`
+if [[ ! "$tmpDir" || ! -d "$tmpDir" ]]; then
+  echo "Could not create temp dir."
+  exit 1
+fi
+
+function cleanup {
+  rm -rf "$tmpDir"
+}
+
+trap cleanup EXIT
+
+pushd $tmpDir >& /dev/null
+
+opsys=windows
+if [[ "$OSTYPE" == linux* ]]; then
+  opsys=linux
+elif [[ "$OSTYPE" == darwin* ]]; then
+  opsys=darwin
+fi
+
+curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
+  grep browser_download |\
+  grep $opsys |\
+  cut -d '"' -f 4 |\
+  grep /kustomize/v3.8.0 |\
+  sort | tail -n 1 |\
+  xargs curl -s -O -L
+
+tar xzf ./kustomize_v*_${opsys}_amd64.tar.gz
+
+cp ./kustomize $where
+
+popd >& /dev/null
+
+./kustomize version
+
+mv kustomize "${INSTALL_DIR}"

--- a/deploy/kubernetes/overlays/dev/WARNING.md
+++ b/deploy/kubernetes/overlays/dev/WARNING.md
@@ -1,0 +1,10 @@
+WARNING: DO NOT USE THE STAGING-LATEST VERSION OF THE DRIVER FOR PRODUCTION
+DISCLAIMER: THE LATEST IMAGE IS CONSTANTLY CHANGING WITH DEVELOPMENT AND CAN BE
+BROKEN AT ANY TIME
+
+This is the absolute cutting edge development Driver, it is intended for testing
+and development only and can have vast differences in
+functionality/behavior/configuration. Use only to try the newest features that
+are not guaranteed to work yet. Authentication works differently for dev overlay,
+and assumes that cluster nodes have set up ADC correctly via scopes. Please check the
+[readme Kubernetes Development](../../../../README.md)

--- a/deploy/kubernetes/overlays/dev/controller_always_pull.yaml
+++ b/deploy/kubernetes/overlays/dev/controller_always_pull.yaml
@@ -1,0 +1,11 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: gcp-filestore-driver
+          imagePullPolicy: Always
+

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../stable
+patchesStrategicMerge:
+- controller_always_pull.yaml
+- node_always_pull.yaml
+- nfs_services_allways_pull.yaml
+- noauth.yaml
+
+namespace: gcp-filestore-csi-driver
+# To change the dev image, add something like the following.
+#images:
+#- name: gcr.io/gke-release/gcp-filestore-csi-driver
+#  newName: <your-gcp-project-image-url>
+#  newTag: <imagetag>

--- a/deploy/kubernetes/overlays/dev/nfs_services_allways_pull.yaml
+++ b/deploy/kubernetes/overlays/dev/nfs_services_allways_pull.yaml
@@ -1,0 +1,11 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: nfs-services
+          imagePullPolicy: Always
+

--- a/deploy/kubernetes/overlays/dev/noauth.yaml
+++ b/deploy/kubernetes/overlays/dev/noauth.yaml
@@ -1,0 +1,25 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: gcp-filestore-driver
+          env:
+            - $patch: delete
+              name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/cloud-sa/gcp_filestore_csi_driver_sa.json"
+          volumeMounts:
+            - $patch: delete
+              name: cloud-sa-volume
+              readOnly: true
+              mountPath: "/etc/cloud_sa"
+      volumes:
+        - $patch: delete
+          name: cloud-sa-volume
+          secret:
+            secretName: gcp-filestore-csi-driver-sa
+
+

--- a/deploy/kubernetes/overlays/dev/node_always_pull.yaml
+++ b/deploy/kubernetes/overlays/dev/node_always_pull.yaml
@@ -1,0 +1,11 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: gcp-filestore-driver
+          imagePullPolicy: Always
+

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../stable
+transformers:
+- ../../images/prow-gke-release-staging-head
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: gcp-filestore-csi-controller
+  path: resizer_timeout_flag_update.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/resizer_timeout_flag_update.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/resizer_timeout_flag_update.yaml
@@ -1,0 +1,8 @@
+# Remove csiTimeout for csi-external-resizer sidecar
+- op: remove
+  path: /spec/template/spec/containers/1/args/2
+
+# Add timeout flag for csi-external-resizer sidecar introduced in 1.0.1
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--timeout=120s"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../stable
+transformers:
+- ../../images/prow-gke-release-staging-rc
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: gcp-filestore-csi-controller
+  path: resizer_timeout_flag_update.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/resizer_timeout_flag_update.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/resizer_timeout_flag_update.yaml
@@ -1,0 +1,8 @@
+# Remove csiTimeout for csi-external-resizer sidecar
+- op: remove
+  path: /spec/template/spec/containers/1/args/2
+
+# Add timeout flag for csi-external-resizer sidecar introduced in 1.0.1
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--timeout=120s"

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+transformers:
+- ../../images/stable

--- a/deploy/project_setup.sh
+++ b/deploy/project_setup.sh
@@ -7,17 +7,22 @@ set -o errexit
 mydir=$(dirname $0)
 source "$mydir/common.sh"
 
-# Cleanup old service account and key
-if [ -f $GCFS_SA_FILE ]; then
-  rm "$GCFS_SA_FILE"
-fi
+readonly DEPLOY_VERSION="${DEPLOY_VERSION:-}"
+
 gcloud projects remove-iam-policy-binding "$PROJECT" --member serviceAccount:"$GCFS_IAM_NAME" --role roles/file.editor || true
 gcloud iam service-accounts delete "$GCFS_IAM_NAME" --quiet || true
 
-# Create new service account and key
 gcloud iam service-accounts create "$GCFS_SA_NAME"
-gcloud iam service-accounts keys create "$GCFS_SA_FILE" --iam-account "$GCFS_IAM_NAME"
 gcloud projects add-iam-policy-binding "$PROJECT" --member serviceAccount:"$GCFS_IAM_NAME" --role roles/file.editor
 
 # Enable Cloud Filestore API for this project.
 gcloud services enable file.googleapis.com
+
+if [ "${DEPLOY_VERSION}" != dev ]; then
+  # Cleanup old service account and key
+  if [ -f $GCFS_SA_FILE ]; then
+    rm "$GCFS_SA_FILE"
+  fi
+  # Create new service account and key
+  gcloud iam service-accounts keys create "$GCFS_SA_FILE" --iam-account "$GCFS_IAM_NAME"
+fi


### PR DESCRIPTION
 staging-head, staging-rc, stable, dev, noauth

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This a prereq patch for enabling k8s e2e integration tests for filestore csi driver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested manually as follows:
1. For noauth overlay, bring up a GCE cluster using kubetest, and deploy the driver using cluster_setup script. Details in the readme.
2. For other overlays tested by deploying the driver in a GKE cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 create overlays for filestore driver
```
