### PR TITLE
Fix CSI e2e test

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -41,7 +41,7 @@ func GCFSClientAndDriverSetup(instance *remote.InstanceInfo) (*remote.TestContex
 		return nil, fmt.Errorf("Could not find environment variable GOPATH")
 	}
 	pkgPath := path.Join(goPath, "src/sigs.k8s.io/gcp-filestore-csi-driver/")
-	binPath := path.Join(pkgPath, "bin/gcfs-csi-driver")
+	binPath := path.Join(pkgPath, "bin/gcp-filestore-csi-driver")
 
 	// Install NFS Libraries
 	_, err := instance.SSH("apt-get", "install", "-y", "nfs-common")
@@ -51,7 +51,7 @@ func GCFSClientAndDriverSetup(instance *remote.InstanceInfo) (*remote.TestContex
 	endpoint := fmt.Sprintf("tcp://localhost:%s", port)
 
 	workspace := remote.NewWorkspaceDir("gcfs-csi-e2e-")
-	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gcfs-csi-driver --endpoint=%s --nodeid=%s --controller=true --node=true > %s/prog.out 2> %s/prog.err < /dev/null &'",
+	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gcp-filestore-csi-driver --endpoint=%s --nodeid=%s --controller=true --node=true > %s/prog.out 2> %s/prog.err < /dev/null &'",
 		workspace, endpoint, instance.GetName(), workspace, workspace)
 
 	config := &remote.ClientConfig{

--- a/test/remote/archiver.go
+++ b/test/remote/archiver.go
@@ -55,7 +55,7 @@ func CreateDriverArchive(archiveName, pkgPath, binPath string) (string, error) {
 
 func setupBinaries(tarDir, pkgPath, binPath string) error {
 	glog.V(4).Infof("Making binaries and copying to temp dir...")
-	out, err := exec.Command("make", "local", "-C", pkgPath).CombinedOutput()
+	out, err := exec.Command("make", "driver", "-C", pkgPath).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Failed to make at %s: %v: %v", pkgPath, string(out), err)
 	}

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -116,13 +116,14 @@ func (c *CsiClient) NodeUnpublishVolume(volumeId, publishDir string) error {
 	return err
 }
 
-func (c *CsiClient) NodePublishVolume(volumeId, publishDir string, volumeAttrs map[string]string) error {
+func (c *CsiClient) NodePublishVolume(volumeId, stageDir, publishDir string, volumeAttrs map[string]string) error {
 	nodePublishReq := &csipb.NodePublishVolumeRequest{
-		VolumeId:         volumeId,
-		TargetPath:       publishDir,
-		VolumeCapability: stdVolCap,
-		VolumeContext:    volumeAttrs,
-		Readonly:         false,
+		VolumeId:          volumeId,
+		StagingTargetPath: stageDir,
+		TargetPath:        publishDir,
+		VolumeCapability:  stdVolCap,
+		VolumeContext:     volumeAttrs,
+		Readonly:          false,
 	}
 	_, err := c.nodeClient.NodePublishVolume(context.Background(), nodePublishReq)
 	return err
@@ -131,4 +132,24 @@ func (c *CsiClient) NodePublishVolume(volumeId, publishDir string, volumeAttrs m
 func (c *CsiClient) NodeGetInfo() (*csipb.NodeGetInfoResponse, error) {
 	resp, err := c.nodeClient.NodeGetInfo(context.Background(), &csipb.NodeGetInfoRequest{})
 	return resp, err
+}
+
+func (c *CsiClient) NodeStageVolume(volumeId, stageDir string, volumeAttrs map[string]string) error {
+	nodeStageReq := &csipb.NodeStageVolumeRequest{
+		VolumeId:          volumeId,
+		StagingTargetPath: stageDir,
+		VolumeCapability:  stdVolCap,
+		VolumeContext:     volumeAttrs,
+	}
+	_, err := c.nodeClient.NodeStageVolume(context.Background(), nodeStageReq)
+	return err
+}
+
+func (c *CsiClient) NodeUnstageVolume(volumeId, stageDir string) error {
+	nodeUnpublishReq := &csipb.NodeUnstageVolumeRequest{
+		VolumeId:          volumeId,
+		StagingTargetPath: stageDir,
+	}
+	_, err := c.nodeClient.NodeUnstageVolume(context.Background(), nodeUnpublishReq)
+	return err
 }

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -84,8 +84,7 @@ func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 		return fmt.Errorf("Failed to create firewall rule: %v", err)
 	}
 
-	// TODO: Pick a better boot disk image
-	imageURL := "projects/ml-images/global/images/family/tf-1-9"
+	imageURL := "projects/debian-cloud/global/images/family/debian-9"
 	inst := &compute.Instance{
 		Name:        i.name,
 		MachineType: machineType(i.zone, ""),
@@ -128,11 +127,11 @@ func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 
 	if _, err := i.computeService.Instances.Get(i.project, i.zone, inst.Name).Do(); err != nil {
 		op, err := i.computeService.Instances.Insert(i.project, i.zone, inst).Do()
-		glog.V(4).Infof("Inserted instance %v in project %v, i.zone %v", inst.Name, i.project, i.zone)
+		glog.V(4).Infof("Inserted instance %v in project: %v, zone: %v", inst.Name, i.project, i.zone)
 		if err != nil {
 			ret := fmt.Sprintf("could not create instance %s: API error: %v", i.name, err)
 			if op != nil {
-				ret = fmt.Sprintf("%s: %v", ret, op.Error)
+				ret = fmt.Sprintf("%s. op error: %v", ret, op.Error)
 			}
 			return fmt.Errorf(ret)
 		} else if op.Error != nil {
@@ -167,7 +166,7 @@ func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 			glog.Warningf("SSH encountered an error: %v, output: %v", err, sshOut)
 			return false, nil
 		}
-		glog.Infof("Instance %v in state RUNNING and vailable by SSH", i.name)
+		glog.Infof("Instance %v in state RUNNING and available by SSH", i.name)
 		return true, nil
 	})
 

--- a/test/run_e2e_local.sh
+++ b/test/run_e2e_local.sh
@@ -4,6 +4,5 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-filestore-csi-driver
-source ${PKGDIR}/deploy/common.sh
 
-ginkgo -v "e2e/tests" --logtostderr -- --project ${PROJECT} --service-account ${GCFS_IAM_NAME}
+ginkgo -v "${PKGDIR}/test/e2e/tests" --logtostderr -- --project ${PROJECT} --service-account ${GCFS_IAM_NAME}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Filestore driver has added new capabilities. The patch ensures the vanilla CSI single zone e2e test passes with the new changes.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested manually by deploying a GCE cluster
1. PROJECT=saikatroyc-gke-dev DEPLOY_VERSION=dev ./deploy/project_setup.sh
2. NODE_SCOPES=https://www.googleapis.com/auth/cloud-platform NODE_SERVICE_ACCOUNT=gcp-filestore-csi-driver-sa@saikatroyc-gke-dev.iam.gserviceaccount.com kubetest --up
3. PROJECT=saikatroyc-gke-dev GCFS_IAM_NAME=gcp-filestore-csi-driver-sa@saikatroyc-gke-dev.iam.gserviceaccount.com ./test/run_e2e_local.sh

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix CSI e2e test
```
