### PR TITLE
Find instance network dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ volume. Customizable parameters for volume creation include:
 | Parameter         | Values                  | Default                                | Description |
 | ---------------   | ----------------------- |-----------                             | ----------- |
 | tier              | "standard"<br>"premium" | "standard"                             | storage performance tier |
-| network           | string                  | "default"                              | VPC name |
+| network           | string                  | Cluster network auto-detected by the driver controller | VPC name |
 | reserved-ipv4-cidr| string		              | ""                                     | CIDR range to allocate Filestore IP Ranges from.<br>The CIDR must be large enough to accommodate multiple Filestore IP Ranges of /29 each |
 
 For Kubernetes clusters, these parameters are specified in the StorageClass.

--- a/examples/kubernetes/demo-sc.yaml
+++ b/examples/kubernetes/demo-sc.yaml
@@ -9,5 +9,5 @@ parameters:
   # # standard (default) or premier
   # tier: premier
   # # Name of the VPC. Note that non-default VPCs require special firewall rules to be setup: TODO
-  # network: default
+  # network: default (If no network is provided, the network on which the driver controller runs is auto detected and filestore instance will be deployed in that network)
 allowVolumeExpansion: true

--- a/pkg/cloud_provider/metadata/fake.go
+++ b/pkg/cloud_provider/metadata/fake.go
@@ -31,3 +31,7 @@ func (manager *fakeServiceManager) GetZone() string {
 func (manager *fakeServiceManager) GetProject() string {
 	return "test-project"
 }
+
+func (manager *fakeServiceManager) GetNetwork() string {
+	return "default"
+}

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -36,8 +36,7 @@ const (
 	modeInstance            = "modeInstance"
 	newInstanceVolume       = "vol1"
 
-	defaultTier    = "standard"
-	defaultNetwork = "default"
+	defaultTier = "standard"
 
 	// Keys for Topology.
 	TopologyKeyZone = "topology.gke.io/zone"
@@ -337,7 +336,7 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 
 	// Set default parameters
 	tier := defaultTier
-	network := defaultNetwork
+	network := s.config.metaService.GetNetwork()
 
 	// Validate parameters (case-insensitive).
 	for k, v := range params {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -36,6 +36,7 @@ const (
 	testVolumeID         = "modeInstance/us-central1-c/test-csi/vol1"
 	testReservedIPV4CIDR = "192.168.92.0/26"
 	testBytes            = 1 * util.Tb
+	defaultNetwork       = "default"
 )
 
 func initTestController(t *testing.T) csi.ControllerServer {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
If no network is provided in the storage class, the driver controller can auto detect the network for the cluster where its running. We have seen kubetest --up by default use a non-default network to create GCE instances. With this patch, we do not need to manually provide the network name in the storage class.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested manually by deploying driver and a demo pod with PVC in both GCE cluster and GKE cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Find instance network dynamically
```
