### PR TITLE
setup kubetest network for k8s e2e test

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -87,6 +87,10 @@ func clusterUpGCE(k8sDir, gceZone string, numNodes int, imageType string) error 
 		}
 	}
 
+	if err = os.Setenv("KUBE_GCE_NETWORK", gceInstanceNetwork); err != nil {
+		return err
+	}
+
 	cmd := exec.Command(filepath.Join(k8sDir, "hack", "e2e-internal", "e2e-up.sh"))
 	err = runCommand("Starting E2E Cluster on GCE", cmd)
 	if err != nil {

--- a/test/k8s-integration/config/fs-sc-basic-hdd.yaml
+++ b/test/k8s-integration/config/fs-sc-basic-hdd.yaml
@@ -4,5 +4,5 @@ metadata:
   name: csi-filestore
 provisioner: filestore.csi.storage.gke.io
 parameters:
-  network: default # Change this network as per the GCE deployment
+  network: csi-filestore-test-network # Change this network as per the GCE deployment
 volumeBindingMode: WaitForFirstConsumer

--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -6,8 +6,9 @@ SnapshotClass:
 {{end}}
 DriverInfo:
   Name: csi-gcpfs-{{.StorageClass}}
+  {{range .SupportedFsType}}
   SupportedFsType:
-  {{range .SupportedFsType}}  {{ . }}:
+    {{ . }}:
   {{end}}
   Capabilities:
   {{range .Capabilities}}  {{ . }}: true

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -77,7 +77,6 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
 		StorageClass:         storageClassFile[:strings.LastIndex(storageClassFile, ".")],
 		SnapshotClassFile:    absSnapshotClassFilePath,
-		SupportedFsType:      []string{},
 		Capabilities:         caps,
 		MinimumVolumeSize:    minimumVolumeSize,
 		NumAllowedTopologies: numAllowedTopologies,

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -56,7 +56,7 @@ var (
 	doDriverBuild     = flag.Bool("do-driver-build", true, "building the driver from source")
 
 	// Test flags
-	testFocus = flag.String("test-focus", "External.Storage.*snapshot", "test focus for Kubernetes e2e")
+	testFocus = flag.String("test-focus", "External.Storage", "test focus for Kubernetes e2e")
 
 	// SA for dev overlay
 	devOverlaySA = flag.String("dev-overlay-sa", "gcp-filestore-csi-driver-sa@saikatroyc-gke-dev.iam.gserviceaccount.com", "default SA that will be plumbed to the GCE instances")
@@ -65,6 +65,8 @@ var (
 const (
 	fsImagePlaceholder      = "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
 	externalDriverNamespace = "gcp-filestore-csi-driver"
+	// If the network name is changed, the same network needs to be provided in storage class template passed in 'storageClassFiles' flag.
+	gceInstanceNetwork = "csi-filestore-test-network"
 )
 
 type testParameters struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR will enable k/k e2e testing of the filestore driver, by deterministically creating a named network, which can be provided in the filestore driver's storage class parameter.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
setup kubetest network for k8s e2e test
```
