### PR TITLE
Remove legacy dep instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,3 @@ See [here](https://cloud.google.com/docs/authentication/production), [here](http
 ```
 $ make skaffold-dev
 ```
-
-### Dependency Management
-Use [dep](https://github.com/golang/dep)
-```
-$ dep ensure
-```


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Remove legacy dep instructions in the README.

```release-note
NONE
```
