### PR TITLE
Add backup and restore e2e test.

### DIFF
--- a/test/e2e/tests/backup_e2e_test.go
+++ b/test/e2e/tests/backup_e2e_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	testutils "sigs.k8s.io/gcp-filestore-csi-driver/test/e2e/utils"
+)
+
+var _ = Describe("Google Cloud Filestore CSI Driver", func() {
+
+	It("Should create -> write -> backup in zone 1 -> restore to zone 2 -> read -> delete", func() {
+		var err error
+		testContext := getRandomTestContext()
+
+		diskInfo, cleanupDisk := createDisk("", "", nil, testContext)
+		defer cleanupDisk()
+		validateDisk(diskInfo)
+
+		// Create Directories
+		stageDir := filepath.Join("/tmp/", diskInfo.Name, "stage")
+		publishDir := filepath.Join("/tmp/", diskInfo.Name, "mount")
+		for _, dir := range []string{stageDir, publishDir} {
+			err = testutils.MkdirAll(testContext.Instance, dir)
+			Expect(err).To(BeNil(), "Mkdir failed with error")
+		}
+		defer func() {
+			// delete remote directory
+			fp := filepath.Join("/tmp/", diskInfo.Name)
+			err = testutils.RmAll(testContext.Instance, fp)
+			Expect(err).To(BeNil(), "Failed to delete remote directory")
+		}()
+
+		testFileName := "testfile-snapshot"
+		testFileContents := "test"
+
+		snapshotURI, cleanupSnapshot := writeAndBackupDisk(testFileName, testFileContents, stageDir, publishDir, diskInfo)
+		defer cleanupSnapshot()
+
+		restoreBackupAndRead(testFileName, testFileContents, stageDir, publishDir, snapshotURI, diskInfo)
+	})
+})
+
+func writeAndBackupDisk(testFileName, testFileContents, stageDir, publishDir string, di *DiskInfo) (string, func()) {
+	cleanupMount := stageAndPublish(stageDir, publishDir, di)
+	defer cleanupMount()
+
+	// Pre-backup write
+	validateWrite(publishDir, testFileName, testFileContents, di.TestCtx.Instance)
+
+	// Backup disk
+	snapshotName := di.Name + "-snapshot"
+	snapshotURI, err := di.TestCtx.Client.CreateSnapshot(snapshotName, di.Volume.GetVolumeId())
+	Expect(err).To(BeNil(), "Create snapshot failed with error")
+
+	// Validate backup exists
+	_, err = fileBackupsService.Get(snapshotURI).Do()
+	Expect(err).To(BeNil(), "Could not get snapshot from cloud directly")
+
+	return snapshotURI, func() {
+		err := di.TestCtx.Client.DeleteSnapshot(snapshotURI)
+		Expect(err).To(BeNil(), "Delete snapshot failed with error")
+
+		_, err = fileBackupsService.Get(snapshotURI).Do()
+		Expect(err).NotTo(BeNil(), "Could get deleted snapshot from cloud directly")
+	}
+}
+
+func restoreBackupAndRead(testFileName, testFileContents, stageDir, publishDir, snapshotURI string, di *DiskInfo) {
+	zone := pickZoneForRestore(di)
+	restoreDiskInfo, cleanupRestoredDisk := createDisk(zone, snapshotURI, nil, di.TestCtx)
+	defer cleanupRestoredDisk()
+	validateDisk(restoreDiskInfo)
+
+	cleanupMount := stageAndPublish(stageDir, publishDir, restoreDiskInfo)
+	defer cleanupMount()
+
+	validateRead(publishDir, testFileName, testFileContents, restoreDiskInfo.TestCtx.Instance)
+}
+
+func pickZoneForRestore(di *DiskInfo) string {
+	// Use a different zone than instance exists in if another zone exists
+	if len(zones) > 1 {
+		for _, z := range zones {
+			_, zone, _ := di.TestCtx.Instance.GetIdentity()
+			if z != zone {
+				return z
+			}
+		}
+	}
+	return ""
+}

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -37,9 +37,11 @@ var (
 	deleteInstances = flag.Bool("delete-instances", false, "Delete the instances after tests run")
 
 	testContexts         = []*remote.TestContext{}
+	zones                []string
 	computeService       *compute.Service
 	fileService          *filev1beta1.Service
 	fileInstancesService *filev1beta1.ProjectsLocationsInstancesService
+	fileBackupsService   *filev1beta1.ProjectsLocationsBackupsService
 )
 
 func TestE2E(t *testing.T) {
@@ -52,7 +54,7 @@ var _ = BeforeSuite(func() {
 	var err error
 	tcc := make(chan *remote.TestContext)
 	defer close(tcc)
-	zones := []string{"us-central1-c", "us-central1-b"}
+	zones = []string{"us-central1-c", "us-central1-b"}
 
 	rand.Seed(time.Now().UnixNano())
 
@@ -63,6 +65,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil())
 
 	fileInstancesService = filev1beta1.NewProjectsLocationsInstancesService(fileService)
+	fileBackupsService = filev1beta1.NewProjectsLocationsBackupsService(fileService)
 
 	if *runInProw {
 		*project, *serviceAccount = testutils.SetupProwConfig()

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/oauth2/google"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 
+	"k8s.io/klog"
 	boskosclient "sigs.k8s.io/boskos/client"
 	remote "sigs.k8s.io/gcp-filestore-csi-driver/test/remote"
 )
@@ -111,6 +112,7 @@ func SetupProwConfig() (project, serviceAccount string) {
 	// Default Compute Engine service account
 	// [PROJECT_NUMBER]-compute@developer.gserviceaccount.com
 	serviceAccount = fmt.Sprintf("%v-compute@developer.gserviceaccount.com", resp.ProjectNumber)
+	klog.V(2).Infof("Prow config utilizing:\n- project %q\n- project number %q\n- service account %q", project, resp.ProjectNumber, serviceAccount)
 	return project, serviceAccount
 }
 

--- a/test/run_e2e.sh
+++ b/test/run_e2e.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-filestore-csi-driver
 
-go test --timeout 20m --v=true "${PKGDIR}/test/e2e/tests" --logtostderr --run-in-prow=true --delete-instances=true
+go test --mod=vendor --timeout 20m --v=true "${PKGDIR}/test/e2e/tests" --logtostderr --run-in-prow=true --delete-instances=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2

**Special notes for your reviewer**:
Backup and restore e2e test does the following: creates disk in same zone as instance, writes to the disk, creates a snapshot, creates a new disk from the snapshot in a different zone than the instance, reads from the disk.

Additionally adds smaller cleanup changes:
- exercises creating custom labels in resize_e2e_test.go
- validates accessibility topology from CreateVolumeResponse.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add backup and restore e2e test.
```
