### PR TITLE
Bump prow rc filestore driver image to v0.3.0-rc1

### DIFF
--- a/build/generate_image_tags.sh
+++ b/build/generate_image_tags.sh
@@ -23,6 +23,10 @@ if [ $(git rev-list -n1 HEAD) == $(git rev-list -n1 origin/master 2>/dev/null) ]
   IMAGE_TAGS+="canary "
 fi
 
+# A "X.Y.Z-canary" image gets built if the current commit is the head of a "origin/release-X.Y.Z" branch.
+# The actual suffix does not matter, only the "release-" prefix is checked.
+IMAGE_TAGS+=$(git branch -r --points-at=HEAD | grep 'origin/release-' | grep -v -e ' -> ' | sed -e 's;.*/release-\(.*\);\1-canary;')
+
 # A release image "vX.Y.Z" gets built if there is a tag of that format for the current commit.
 # --abbrev=0 suppresses long format, only showing the closest tag.
 LATEST_GIT_TAG=$(git describe --tags --match='v*' --abbrev=0)
@@ -38,8 +42,6 @@ if [ $LATEST_TAG_REV ] && [ $LATEST_TAG_REV == $HEAD_REV ]; then
   IMAGE_TAGS+=$LATEST_GIT_TAG
   IMAGE_TAGS+=" "
 fi
-
-# TODO: Create "X.Y.Z-canary" TAG when release-X.Y.Z branch created
 
 # If we did not detect any IMAGE_TAGS, then use the latest git head
 # commit as the image tag.

--- a/deploy/kubernetes/base/controller/controller.yaml
+++ b/deploy/kubernetes/base/controller/controller.yaml
@@ -23,7 +23,7 @@ spec:
       priorityClassName: csi-gcp-fs-controller
       containers:
         - name: csi-external-provisioner
-          image: gcr.io/gke-release/csi-provisioner
+          image: k8s.gcr.io/sig-storage/csi-provisioner
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -34,16 +34,16 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-resizer
-          image: gcr.io/gke-release/csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - "--csiTimeout=120s"
+            - "--timeout=120s"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-snapshotter
-          image: gcr.io/gke-release/csi-snapshotter
+          image: k8s.gcr.io/sig-storage/csi-snapshotter
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -52,8 +52,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: gcp-filestore-driver
-          # Modify this image for local development with master branch.
-          image: gcr.io/gke-release/gcp-filestore-csi-driver
+          image: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
           args:
             - "--v=4"
             - "--endpoint=unix:/csi/csi.sock"

--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -25,7 +25,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-node-driver-registrar:v1.3.0-gke.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -43,8 +43,7 @@ spec:
         - name: gcp-filestore-driver
           securityContext:
             privileged: true
-          # Modify this image for local development with master branch.
-          image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0
+          image: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"
@@ -62,8 +61,7 @@ spec:
             - name: plugin-dir
               mountPath: /csi
         - name: nfs-services
-          # Modify this image for local development with master branch.
-          image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0
+          image: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
           command: ["/nfs_services_start.sh"]
       volumes:
         - name: registration-dir

--- a/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
@@ -3,18 +3,8 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-provisioner-prow-head
 imageTag:
-  name: gcr.io/gke-release/csi-provisioner
-  newName: quay.io/k8scsi/csi-provisioner
-  newTag: "canary"
----
-
-apiVersion: builtin
-kind: ImageTagTransformer
-metadata:
-  name: imagetag-csi-attacher-prow-head
-imageTag:
-  name: gcr.io/gke-release/csi-attacher
-  newName: quay.io/k8scsi/csi-provisioner
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newName: gcr.io/k8s-staging-sig-storage/csi-provisioner
   newTag: "canary"
 ---
 
@@ -23,8 +13,8 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-resize-prow-head
 imageTag:
-  name: gcr.io/gke-release/csi-resizer
-  newName: quay.io/k8scsi/csi-resizer
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newName: gcr.io/k8s-staging-sig-storage/csi-resizer
   newTag: "canary"
 ---
 
@@ -33,19 +23,8 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-snapshotter-prow-head
 imageTag:
-  name: gke.gcr.io/csi-snapshotter
-  newName: quay.io/k8scsi/csi-provisioner
-  newTag: "canary"
----
-
-apiVersion: builtin
-kind: ImageTagTransformer
-metadata:
-  name: imagetag-csi-gce-driver-prow-head
-imageTag:
-  name: gcr.io/gke-release/gcp-filestore-csi-driver
-  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
-  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newName: gcr.io/k8s-staging-sig-storage/csi-snapshotter
   newTag: "canary"
 ---
 
@@ -54,7 +33,16 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-node-registrar-prow-head
 imageTag:
-  name: gcr.io/gke-release/csi-node-driver-registrar
-  newName: quay.io/k8scsi/csi-node-driver-registrar
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newName: gcr.io/k8s-staging-sig-storage/csi-node-driver-registrar
+  newTag: "canary"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-gce-driver-prow-head
+imageTag:
+  name: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
   newTag: "canary"
 ---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
@@ -3,19 +3,8 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-provisioner
-  newName: gcr.io/gke-release-staging/csi-provisioner
-  newTag: "v1.6.0-gke.0"
----
-
-apiVersion: builtin
-kind: ImageTagTransformer
-metadata:
-  name: imagetag-csi-attacher-prow-rc
-imageTag:
-  name: gcr.io/gke-release/csi-attacher
-  newName: gcr.io/gke-release-staging/csi-attacher
-  newTag: "v2.2.0-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v1.6.0"
 ---
 
 apiVersion: builtin
@@ -23,30 +12,17 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-resizer
-  newName: gcr.io/gke-release-staging/csi-resizer
-  newTag: "v1.0.1-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.0.1"
 ---
 
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-csi-snapshotter-prow-head
+  name: imagetag-csi-snapshotter-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-snapshotter
-  newName: gcr.io/gke-release-staging/csi-snapshotter
-  newTag: "v2.1.1-gke.0"
----
-
-apiVersion: builtin
-kind: ImageTagTransformer
-metadata:
-  name: imagetag-csi-gce-driver-prow-rc
-imageTag:
-  name: gcr.io/gke-release/gcp-filestore-csi-driver
-  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
-  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
-  newTag: "canary"
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.2"
 ---
 
 apiVersion: builtin
@@ -54,7 +30,15 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-node-driver-registrar
-  newName: gcr.io/gke-release-staging/csi-node-driver-registrar
-  newTag: "v1.3.0-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.0-rc1"
 ---

--- a/deploy/kubernetes/images/stable/image.yaml
+++ b/deploy/kubernetes/images/stable/image.yaml
@@ -1,55 +1,44 @@
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-csi-provisioner
+  name: imagetag-csi-provisioner-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-provisioner
-  newTag: "v1.6.0-gke.0"
-
----
-apiVersion: builtin
-kind: ImageTagTransformer
-metadata:
-  name: imagetag-csi-attacher
-imageTag:
-  name: gcr.io/gke-release/csi-attacher
-  newTag: "v2.2.0-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v1.6.0"
 ---
 
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-csi-resizer
+  name: imagetag-csi-resize-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-resizer
-  newTag: "v0.5.0-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.0.1"
 ---
 
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-csi-snapshotter
+  name: imagetag-csi-snapshotter-prow-rc
 imageTag:
-  name: gcr.io/gke-release/csi-snapshotter
-  newTag: "v2.1.1-gke.0"
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.2"
 ---
 
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-gcpfs-driver
+  name: imagetag-csi-node-registrar-prow-rc
 imageTag:
-  name: gcr.io/gke-release/gcp-filestore-csi-driver
-  # TODO: Change the image to k8s-cloud-provider-gcp when an image is available
-  newName: "gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver"
-  newTag: "canary"
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
 ---
 
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-csi-node-registrar
+  name: imagetag-gce-fs-driver-rc
 imageTag:
-  name: gcr.io/gke-release/csi-node-driver-registrar
-  newTag: "v1.3.0-gke.0"
+  name: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.0-rc1"
 ---

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -4,10 +4,3 @@ resources:
 - ../stable
 transformers:
 - ../../images/prow-gke-release-staging-rc
-patchesJson6902:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: gcp-filestore-csi-controller
-  path: resizer_timeout_flag_update.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/resizer_timeout_flag_update.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/resizer_timeout_flag_update.yaml
@@ -1,8 +1,0 @@
-# Remove csiTimeout for csi-external-resizer sidecar
-- op: remove
-  path: /spec/template/spec/containers/1/args/2
-
-# Add timeout flag for csi-external-resizer sidecar introduced in 1.0.1
-- op: add
-  path: /spec/template/spec/containers/1/args/-
-  value: "--timeout=120s"


### PR DESCRIPTION
1. Use k8s.gcr.io images for sidecar
2. Use v0.3.0-rc1 for prow-gke-release-staging-rc
3. Remove attacher image tags
4. Remove resizer timeout patch, since we are now using 1.x and above for all overlays which use 'timeout' flag.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
