### PR TITLE
Add configurable timeouts for k8s e2e tests

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -4,12 +4,18 @@ StorageClass:
 SnapshotClass:
   FromFile: {{ .SnapshotClassFile }}
 {{end}}
+{{if .Timeouts}}
+Timeouts:
+  {{ range $key, $value := .Timeouts }}{{ $key }}: {{ $value }}
+  {{ end }}
+{{end}}
 DriverInfo:
   Name: csi-gcpfs-{{.StorageClass}}
-  {{range .SupportedFsType}}
+{{if .SupportedFsType}}
   SupportedFsType:
-    {{ . }}:
+  {{range .SupportedFsType}}  {{ . }}:
   {{end}}
+{{end}}
   Capabilities:
   {{range .Capabilities}}  {{ . }}: true
   {{end}}

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -17,12 +17,21 @@ type driverConfig struct {
 	SupportedFsType      []string
 	MinimumVolumeSize    string
 	NumAllowedTopologies int
+	Timeouts             map[string]string
 }
 
 const (
 	testConfigDir      = "test/k8s-integration/config"
 	configTemplateFile = "test-config-template.in"
 	configFile         = "test-config.yaml"
+
+	// configurable timeouts for the k8s e2e testsuites.
+	podStartTimeout       = "600s"
+	claimProvisionTimeout = "600s"
+
+	// These are keys for the configurable timeout map.
+	podStartTimeoutKey       = "PodStart"
+	claimProvisionTimeoutKey = "ClaimProvision"
 )
 
 // generateDriverConfigFile loads a testdriver config template and creates a file
@@ -73,6 +82,12 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 
 	minimumVolumeSize := "1Ti"
 	numAllowedTopologies := 1
+	// Filestore instance takes in the order of minutes to be provisioned, and with dynamic provisioning (WaitForFirstCustomer policy),
+	// some e2e tests need a longer pod start timeout.
+	timeouts := map[string]string{
+		claimProvisionTimeoutKey: claimProvisionTimeout,
+		podStartTimeoutKey:       podStartTimeout,
+	}
 	params := driverConfig{
 		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
 		StorageClass:         storageClassFile[:strings.LastIndex(storageClassFile, ".")],
@@ -80,6 +95,7 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		Capabilities:         caps,
 		MinimumVolumeSize:    minimumVolumeSize,
 		NumAllowedTopologies: numAllowedTopologies,
+		Timeouts:             timeouts,
 	}
 
 	// Write config file

--- a/test/k8s-integration/driver.go
+++ b/test/k8s-integration/driver.go
@@ -113,8 +113,8 @@ func pushImage(pkgDir, stagingImage, stagingVersion string) error {
 	var cmd *exec.Cmd
 
 	cmd = exec.Command("make", "-C", pkgDir, "build-image-and-push",
-		fmt.Sprintf("GCE_PD_CSI_STAGING_VERSION=%s", stagingVersion),
-		fmt.Sprintf("GCE_PD_CSI_STAGING_IMAGE=%s", stagingImage))
+		fmt.Sprintf("GCP_FS_CSI_STAGING_VERSION=%s", stagingVersion),
+		fmt.Sprintf("GCP_FS_CSI_STAGING_IMAGE=%s", stagingImage))
 	err = runCommand("Pushing GCP Container for Linux", cmd)
 	if err != nil {
 		return fmt.Errorf("failed to run make command for linux: err: %v", err)

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -393,7 +393,7 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 
 	kubeTestArgs := []string{
 		"--test",
-		"--ginkgo-parallel",
+		"--ginkgo-parallel=3",
 		"--check-version-skew=false",
 		fmt.Sprintf("--test_args=%s", testArgs),
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Add configurable timeouts for k8s e2e tests. This PR uses [this](https://github.com/kubernetes/kubernetes/pull/96042) enhancement 
to configure timeouts 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This patch should go in after [this](https://github.com/kubernetes/kubernetes/pull/96042) is merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
