### PR TITLE
Add workaround for intermittent docker COPY error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get autoremove -y && \
 FROM deps
 ARG DRIVERBINARY
 COPY --from=builder /go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/${DRIVERBINARY} /${DRIVERBINARY}
+RUN true
 COPY deploy/kubernetes/nfs_services_start.sh /nfs_services_start.sh
 
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In latest cloudbuild run, https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gcp-filestore-push-images/1336025493018775552, I see the build failed ```failed to export image: failed to create image: failed to get layer sha256:89bf40ff6a6874efd8353325c7aac1e9058d445e3fae996f6a64f78aa91fd587: layer does not exist```

I haven't been able to repro the issue locally on my setup. Suggestion from the docker community is to add a `RUN true` between COPY instructions in the dockerfile. See [here](https://github.com/moby/moby/issues/37965#issuecomment-426853382)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
