### PR TITLE
Cherrypick #94 #95 from `master` to `release-0.3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get autoremove -y && \
 FROM deps
 ARG DRIVERBINARY
 COPY --from=builder /go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/${DRIVERBINARY} /${DRIVERBINARY}
+RUN true
 COPY deploy/kubernetes/nfs_services_start.sh /nfs_services_start.sh
 
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 # Core Filestore CSI driver binary
 DRIVERBINARY=gcp-filestore-csi-driver
 
+$(info PULL_BASE_REF is $(PULL_BASE_REF))
+$(info GIT_TAG is $(GIT_TAG))
+
 # A space-separated list of image tags under which the current build is to be pushed.
 # Determined dynamically.
 STAGINGVERSION=


### PR DESCRIPTION
Cherrypick PR #94 : Use PULL_BASE_REF to generate driver image tags
Cherrypick PR #95 : Add workaround for intermittent docker COPY error 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
With this patch, I want to check if 0.3-canary image gets created.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
