### PR TITLE
k8s minor version overlays

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
@@ -1,0 +1,36 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v1.6.1"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
@@ -1,0 +1,45 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
@@ -1,0 +1,45 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
@@ -1,0 +1,45 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -1,0 +1,45 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v4.0.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow-rc
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver-rc
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-1-16/image.yaml
+++ b/deploy/kubernetes/images/stable-1-16/image.yaml
@@ -1,0 +1,35 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v1.6.1"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-1-16/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-1-16/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-1-17/image.yaml
+++ b/deploy/kubernetes/images/stable-1-17/image.yaml
@@ -1,0 +1,44 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-1-17/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-1-17/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-1-18/image.yaml
+++ b/deploy/kubernetes/images/stable-1-18/image.yaml
@@ -1,0 +1,44 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-1-18/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-1-18/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-1-18/stable/image.yaml
+++ b/deploy/kubernetes/images/stable-1-18/stable/image.yaml
@@ -1,0 +1,44 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-1-18/stable/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-1-18/stable/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-1-19/image.yaml
+++ b/deploy/kubernetes/images/stable-1-19/image.yaml
@@ -1,0 +1,44 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v3.0.3"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-1-19/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-1-19/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -1,0 +1,44 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v2.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-resize-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-resizer
+  newTag: "v1.1.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-snapshotter-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-snapshotter
+  newTag: "v4.0.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-node-registrar-prow
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  newTag: "v1.3.0"
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-gce-fs-driver
+imageTag:
+  name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
+  newTag: "v0.3.1"
+---

--- a/deploy/kubernetes/images/stable-master/kustomization.yaml
+++ b/deploy/kubernetes/images/stable-master/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- image.yaml

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable
+- ../stable-master
 patchesStrategicMerge:
 - controller_always_pull.yaml
 - node_always_pull.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/resizer_timeout_flag_update.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/resizer_timeout_flag_update.yaml
@@ -1,8 +1,0 @@
-# Remove csiTimeout for csi-external-resizer sidecar
-- op: remove
-  path: /spec/template/spec/containers/1/args/2
-
-# Add timeout flag for csi-external-resizer sidecar introduced in 1.0.1
-- op: add
-  path: /spec/template/spec/containers/1/args/-
-  value: "--timeout=120s"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-16/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-16/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-16/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-16/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable-master
+- ../stable-1-16
 transformers:
-- ../../images/prow-gke-release-staging-head
+- ../../images/prow-gke-release-staging-rc-1-16

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-17/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-17/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-17/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-17/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable-master
+- ../stable-1-17
 transformers:
-- ../../images/prow-gke-release-staging-head
+- ../../images/prow-gke-release-staging-rc-1-17

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable-master
+- ../stable-1-18
 transformers:
-- ../../images/prow-gke-release-staging-head
+- ../../images/prow-gke-release-staging-rc-1-18

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable-master
+- ../stable-1-19
 transformers:
-- ../../images/prow-gke-release-staging-head
+- ../../images/prow-gke-release-staging-rc-1-19

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/README.md
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/README.md
@@ -1,0 +1,1 @@
+These overlays are intended to be only used by prow for CI testing.

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - ../stable-master
 transformers:
-- ../../images/prow-gke-release-staging-head
+- ../../images/prow-gke-release-staging-rc-master

--- a/deploy/kubernetes/overlays/stable-1-16/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-16/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+patchesStrategicMerge:
+- no_snapshotter_sidecar.yaml
+- no_snapshotter_roles.yaml
+transformers:
+- ../../images/stable-1-16

--- a/deploy/kubernetes/overlays/stable-1-16/no_snapshotter_roles.yaml
+++ b/deploy/kubernetes/overlays/stable-1-16/no_snapshotter_roles.yaml
@@ -1,0 +1,34 @@
+# TODO: Check if we can remove the snapshot, snapshotcontent get list roles for provisioner
+$patch: delete
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-filestore-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+---
+$patch: delete
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: gcp-filestore-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/deploy/kubernetes/overlays/stable-1-16/no_snapshotter_sidecar.yaml
+++ b/deploy/kubernetes/overlays/stable-1-16/no_snapshotter_sidecar.yaml
@@ -1,0 +1,18 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gcp-filestore-csi-controller
+spec:
+  template:
+    spec:
+      containers:
+        - $patch: delete
+          name: csi-external-snapshotter
+          image: k8s.gcr.io/sig-storage/csi-snapshotter
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--timeout=300s"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi

--- a/deploy/kubernetes/overlays/stable-1-17/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-17/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+transformers:
+- ../../images/stable-1-17

--- a/deploy/kubernetes/overlays/stable-1-18/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-18/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+transformers:
+- ../../images/stable-1-18

--- a/deploy/kubernetes/overlays/stable-1-19/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-19/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+transformers:
+- ../../images/stable-1-19

--- a/deploy/kubernetes/overlays/stable-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-master/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace:
+  gcp-filestore-csi-driver
+resources:
+- ../../base/controller
+- ../../base/node_linux
+transformers:
+- ../../images/stable-master

--- a/test/k8s-integration/config/fs-sc-basic-hdd-default-network.yaml
+++ b/test/k8s-integration/config/fs-sc-basic-hdd-default-network.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-filestore
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,13 +62,7 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		"RWX",
 		"multipods",
 		"topology",
-	}
-
-	switch testParams.deploymentStrategy {
-	case "gce":
-		caps = append(caps, "controllerExpansion")
-	default:
-		return "", fmt.Errorf("got unknown deployment strat %s, expected gce or gke", testParams.deploymentStrategy)
+		"controllerExpansion",
 	}
 
 	var absSnapshotClassFilePath string

--- a/test/k8s-integration/version.go
+++ b/test/k8s-integration/version.go
@@ -1,0 +1,142 @@
+// main.version is used to parse and compare GKE based versions.
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+var (
+	versionNum           = `(0|[1-9][0-9]*)`
+	internalPatchVersion = `(\-[a-zA-Z0-9_.+-]+)`
+
+	versionRegex         = regexp.MustCompile(`^` + versionNum + `\.` + versionNum + `\.` + versionNum + internalPatchVersion + "?$")
+	gkeExtraVersionRegex = regexp.MustCompile(`^(?:gke)\.(0|[1-9][0-9]*)$`)
+)
+
+type version struct {
+	version [4]int
+}
+
+func (v *version) String() string {
+	if v.version[3] != -1 {
+		return fmt.Sprintf("%d.%d.%d-gke.%d", v.version[0], v.version[1], v.version[2], v.version[3])
+	}
+
+	return fmt.Sprintf("%d.%d.%d", v.version[0], v.version[1], v.version[2])
+}
+
+func (v *version) major() int {
+	return v.version[0]
+}
+
+func (v *version) minor() int {
+	return v.version[1]
+}
+
+func (v *version) patch() int {
+	return v.version[2]
+}
+
+func (v *version) extra() int {
+	return v.version[3]
+}
+
+func (v *version) isGKEExtraVersion(extrastr string) bool {
+	return gkeExtraVersionRegex.MatchString(extrastr)
+}
+
+func extractGKEExtraVersion(extra string) (int, error) {
+	m := gkeExtraVersionRegex.FindStringSubmatch(extra)
+	if len(m) != 2 {
+		return -1, fmt.Errorf("Invalid GKE Patch version %q", extra)
+	}
+
+	v, err := strconv.Atoi(m[1])
+	if err != nil {
+		return -1, fmt.Errorf("GKE extra version atoi failed: %q", extra)
+	}
+
+	if v < 0 {
+		return -1, fmt.Errorf("GKE extra version check failed: %q", extra)
+	}
+	return v, nil
+}
+
+func parseVersion(vs string) (*version, error) {
+	// If version has a prefix 'v', remove it before parsing.
+	if strings.HasPrefix(vs, "v") {
+		vs = vs[1:]
+	}
+
+	submatches := versionRegex.FindStringSubmatch(vs)
+	if submatches == nil {
+		return nil, fmt.Errorf("version %q is invalid", vs)
+	}
+
+	var v version
+	// submatches[0] is the whole match, [1]..[3] are the version bits, [4] is the extra
+	for i, sm := range submatches[1:4] {
+		var err error
+		if v.version[i], err = strconv.Atoi(sm); err != nil {
+			return nil, fmt.Errorf("submatch %q failed atoi conversion", sm)
+		}
+	}
+
+	// Ensure 1.X.Y < 1.X.Y-gke.0
+	v.version[3] = -1
+	if submatches[4] != "" {
+		extrastr := submatches[4][1:]
+		if v.isGKEExtraVersion(extrastr) {
+			ver, err := extractGKEExtraVersion(extrastr)
+			if err != nil {
+				return nil, err
+			}
+			v.version[3] = ver
+		} else {
+			return nil, fmt.Errorf("GKE extra version check failed: %q", extrastr)
+		}
+	}
+
+	return &v, nil
+}
+
+// mustParseVersion parses a GKE cluster version.
+func mustParseVersion(version string) *version {
+	v, err := parseVersion(version)
+	if err != nil {
+		klog.Fatalf("Failed to parse GKE version: %q", version)
+	}
+	return v
+}
+
+// Helper function to compare versions.
+//  -1 -- if left  < right
+//   0 -- if left == right
+//   1 -- if left  > right
+func (v *version) compare(right *version) int {
+	for i, b := range v.version {
+		if b > right.version[i] {
+			return 1
+		}
+		if b < right.version[i] {
+			return -1
+		}
+	}
+
+	return 0
+}
+
+// Compare versions if left is strictly less than right.
+func (v *version) lessThan(right *version) bool {
+	return v.compare(right) < 0
+}
+
+// Compare versions if left is greater than or equal to right.
+func (v *version) atLeast(right *version) bool {
+	return v.compare(right) >= 0
+}

--- a/test/k8s-integration/version_test.go
+++ b/test/k8s-integration/version_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		version   string
+		expectErr bool
+		expectedV version
+	}{
+		// Positive test cases.
+		{
+			version: "v1.1.1",
+			expectedV: version{
+				version: [4]int{1, 1, 1, -1},
+			},
+		},
+		{
+			version: "v1.18.0",
+			expectedV: version{
+				version: [4]int{1, 18, 0, -1},
+			},
+		},
+		{
+			version: "v1.18.0-gke.0",
+			expectedV: version{
+				version: [4]int{1, 18, 0, 0},
+			},
+		},
+		{
+			version: "1.18.3-gke.10",
+			expectedV: version{
+				version: [4]int{1, 18, 3, 10},
+			},
+		},
+		{
+			version: "1.18.9",
+			expectedV: version{
+				version: [4]int{1, 18, 9, -1},
+			},
+		},
+		{
+			version: "1.18.10-gke.10",
+			expectedV: version{
+				version: [4]int{1, 18, 10, 10},
+			},
+		},
+		{
+			version: "10.18.10-gke.10",
+			expectedV: version{
+				version: [4]int{10, 18, 10, 10},
+			},
+		},
+		{
+			version: "100.101.102-gke.103",
+			expectedV: version{
+				version: [4]int{100, 101, 102, 103},
+			},
+		},
+		// Negative test cases
+		{
+			version:   "1",
+			expectErr: true,
+		},
+		{
+			version:   "-1.18.9",
+			expectErr: true,
+		},
+		{
+			version:   "1.-18.9",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.-9",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9-gke.-1",
+			expectErr: true,
+		},
+		{
+			version:   "1.1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9.1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9-1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18-gke.0",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.0-alpha.x",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.0-alpha.beta.1",
+			expectErr: true,
+		},
+		{
+			version:   "alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+		{
+			version:   "1.18-alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.3-alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run("TestCase"+strconv.Itoa(i), func(t *testing.T) {
+			gotV, err := parseVersion(tc.version)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Got unexpected err: %v", err)
+				}
+				return
+			}
+
+			if err == nil && tc.expectErr {
+				t.Fatal("Got no error but expected one")
+				return
+			}
+
+			if gotV.version[0] != tc.expectedV.version[0] ||
+				gotV.version[1] != tc.expectedV.version[1] ||
+				gotV.version[2] != tc.expectedV.version[2] ||
+				gotV.version[3] != tc.expectedV.version[3] {
+				t.Fatalf("Got version: %s, expected: %s", gotV.String(), tc.expectedV.String())
+			}
+		})
+	}
+}
+
+func TestIsVersionLessThan(t *testing.T) {
+	tests := []struct {
+		leftVersion  string
+		rightVersion string
+		expectRes    bool
+	}{
+		// Positive cases (left < right).
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "1.17.6",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "1.18.5",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "2.17.5",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.1-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.19.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "2.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0-gke.1",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.0-gke.9",
+			rightVersion: "1.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "1.18.1-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "1.19.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "2.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.1",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.19.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "2.18.0",
+			expectRes:    true,
+		},
+		// Negative test cases.(left == right)
+		{
+			leftVersion:  "0.0.0",
+			rightVersion: "0.0.0",
+		},
+		{
+			leftVersion:  "1.1.1",
+			rightVersion: "1.1.1",
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0-gke.0",
+		},
+		// Negative test cases.(left > right)
+		{
+			leftVersion:  "1.17.6",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "1.18.5",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "2.17.5",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.1-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.19.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "2.18.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.1",
+			rightVersion: "1.18.0-gke.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.17.0-gke.9",
+		},
+		{
+			leftVersion:  "1.18.1-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "1.19.0-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "2.18.0-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "1.18.1",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.19.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "2.18.0",
+			rightVersion: "1.18.0",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run("TestCase"+strconv.Itoa(i), func(t *testing.T) {
+			left, err := parseVersion(tc.leftVersion)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+				return
+			}
+			right, err := parseVersion(tc.rightVersion)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+				return
+			}
+
+			got := left.lessThan(right)
+			if got != tc.expectRes {
+				t.Fatalf("Unpexpected compare value: %v, expected %v, left: %q, right: %q", got, tc.expectRes, left.String(), right.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This patch enables creating overlays per k8s minor version. The overlays capture the manifest bundle for the driver for a given k8s version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Summary of changes:
1. mapping of overlay to sidecar images
```
stable-1-16, prow-gke-release-staging-rc-1-16:
provisioner: 1.6.1
resizer: 1.1.0
node registrar: 1.3.0
filestore driver:0.3.1

stable-1-17, prow-gke-release-staging-rc-1-17:
stable-1-18, prow-gke-release-staging-rc-1-18:
stable-1-19, prow-gke-release-staging-rc-1-19:
provisioner: 2.1.0
resizer: 1.1.0
snapshotter:3.0.3
node registrar: 1.3.0
filestore driver:0.3.1

stable-master, prow-gke-release-staging-rc-master:
provisioner: 2.1.0
resizer: 1.1.0
snapshotter:4.0.0
node registrar: 1.3.0
filestore driver:0.3.1
```
2. Add test infra to run k8s integration test on GKE. This enables testing the various overlays on GKE and GCE.

TODO items in future patches:
1. add internal prow jobs to test the prow-gke-release-staging-rc* overlays and verify things work.
2. Remove the old prow prow-gke-release-staging-rc and stable overlays and the respective jobs, and point run-k8s-integration.sh to default stable-master overlay.
3. Update readme

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Split the overlays into per k8s minor version
```
