### PR TITLE
Add support for fsGroupPolicy in CSI driver object

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/fsgrouppolicy.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/fsgrouppolicy.yaml
@@ -1,0 +1,9 @@
+$patch: replace
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: filestore.csi.storage.gke.io
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  fsGroupPolicy: File

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../stable-master
+patchesStrategicMerge:
+- fsgrouppolicy.yaml
 transformers:
 - ../../images/prow-gke-release-staging-rc-master

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -388,6 +388,10 @@ func generateGCETestSkip(testParams *testParameters) string {
 	if v.LessThan(apimachineryversion.MustParseSemantic("1.17.0")) {
 		skipString = skipString + "|VolumeSnapshotDataSource"
 	}
+
+	if v.LessThan(apimachineryversion.MustParseSemantic("1.20.0")) {
+		skipString = skipString + "|fsgroupchangepolicy"
+	}
 	return skipString
 }
 
@@ -406,8 +410,10 @@ func generateGKETestSkip(testParams *testParameters) string {
 		skipString = skipString + "|allowExpansion"
 	}
 
-	// Skip fsgroup change policy tests until the filestore csi driver supports it.
-	skipString = skipString + "|fsgroupchangepolicy"
+	// Skip fsgroup change policy based on GKE cluster version.
+	if curVer.lessThan(mustParseVersion("1.20.0")) {
+		skipString = skipString + "|fsgroupchangepolicy"
+	}
 
 	// Running snapshot tests on GKE needs k8s 1.19x storage e2e testsuite (until GKE supports v1 snapshot APIs).
 	// And to run 1.19x test suite for filestore, https://github.com/kubernetes/kubernetes/pull/96042 needs to be cherry-picked


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR enables fsgroup support for Filestore CSI driver in 1.20+ clusters. The current PR enables the feature in prow-gke-release-staging-rc-master. Once we have a stable run of k/k fsgrouppolicy [testsuite](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/testsuites/fsgroupchangepolicy.go), followup patches will enable the feature for stable-master and README updates. When we create 1.20 overlay, the change will be included there too.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested locally by running External.*storage.* fsgroupchangepolicy tests on k8s master on GCE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for fsGroupPolicy in CSI driver object for prow-gke-release-staging-rc-master overlay
```
