### PR TITLE
images: update image repositories

### DIFF
--- a/deploy/kubernetes/manifests/controller.yaml
+++ b/deploy/kubernetes/manifests/controller.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccount: gcp-filestore-csi-controller-sa
       containers:
         - name: csi-external-provisioner
-          image: gcr.io/gke-release/csi-provisioner:v1.6.0-gke.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -30,7 +30,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-resizer
-          image: gcr.io/gke-release/csi-resizer:v0.5.0-gke.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-external-snapshotter
-          image: gcr.io/gke-release/csi-snapshotter:v2.1.1-gke.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/kubernetes/manifests/node.yaml
+++ b/deploy/kubernetes/manifests/node.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-node-driver-registrar:v1.3.0-gke.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

This PR update the images to the ones that are available in the community registry

there is this image `gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0` that is not available as well in the community, or at least I did not find it.
Should we setup a project to build and publish this or reuse the sig-storage project for that?

/assign @spiffxp @saad-ali

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
