### PR TITLE
driver binary reference fix in filestore image build + fsgroup policy overlay patch fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get autoremove -y && \
 
 # Copy driver into image
 FROM deps
-ARG DRIVERBINARY
+ARG DRIVERBINARY=gcp-filestore-csi-driver
 COPY --from=builder /go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/${DRIVERBINARY} /${DRIVERBINARY}
 RUN true
 COPY deploy/kubernetes/nfs_services_start.sh /nfs_services_start.sh

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ image:
 		{                                                                   \
 		set -e ;                                                            \
 		for i in $(STAGINGVERSION) ;                                        \
-			do docker build --build-arg DRIVERBINARY=$${DRIVERBINARY} -t $(STAGINGIMAGE):$${i} .; \
+			do docker build --build-arg DRIVERBINARY=$(DRIVERBINARY) -t $(STAGINGIMAGE):$${i} .; \
 		done ;                                                              \
 		}
 

--- a/deploy/kubernetes/overlays/stable-master/fsgrouppolicy.yaml
+++ b/deploy/kubernetes/overlays/stable-master/fsgrouppolicy.yaml
@@ -1,9 +1,3 @@
-$patch: replace
-apiVersion: storage.k8s.io/v1beta1
-kind: CSIDriver
-metadata:
-  name: filestore.csi.storage.gke.io
-spec:
-  attachRequired: false
-  podInfoOnMount: true
-  fsGroupPolicy: File
+- op: add
+  path: "/spec/fsGroupPolicy"
+  value: File

--- a/deploy/kubernetes/overlays/stable-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-master/kustomization.yaml
@@ -5,7 +5,10 @@ namespace:
 resources:
 - ../../base/controller
 - ../../base/node_linux
-patchesStrategicMerge:
-- fsgrouppolicy.yaml
+patchesJson6902:
+ - target:
+     kind: CSIDriver
+     name: filestore.csi.storage.gke.io
+   path: fsgrouppolicy.yaml
 transformers:
 - ../../images/stable-master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

9974f47cce88524004f6a55b0a176cd1b11699d1: With this fix, the DRIVERBINARY should be expected to be initialized correctly while building the docker image. (needs to be verified with a real image built by the GCB)
683d0000f046234512a910ca316e45c79a6f5cab: Fix fsgroup policy overlay patch for stable-master


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
