### PR TITLE
Fix driver image binary path in dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 FROM golang:1.14.4 as builder
 WORKDIR /go/src/sigs.k8s.io/gcp-filestore-csi-driver
 ADD . .
-RUN make driver
+RUN make driver BINDIR=/bin
 
 # Install nfs packages
 FROM launcher.gcr.io/google/debian9 as deps
@@ -83,7 +83,7 @@ RUN apt-get autoremove -y && \
 # Copy driver into image
 FROM deps
 ARG DRIVERBINARY=gcp-filestore-csi-driver
-COPY --from=builder /go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/${DRIVERBINARY} /${DRIVERBINARY}
+COPY --from=builder /bin/${DRIVERBINARY} /${DRIVERBINARY}
 RUN true
 COPY deploy/kubernetes/nfs_services_start.sh /nfs_services_start.sh
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DRIVERBINARY=gcp-filestore-csi-driver
 
 $(info PULL_BASE_REF is $(PULL_BASE_REF))
 $(info GIT_TAG is $(GIT_TAG))
+$(info PWD is $(PWD))
 
 # A space-separated list of image tags under which the current build is to be pushed.
 # Determined dynamically.
@@ -35,6 +36,8 @@ else
 	STAGINGIMAGE=gcr.io/$(PROJECT)/gcp-filestore-csi-driver
 endif
 $(info STAGINGIMAGE is $(STAGINGIMAGE))
+
+BINDIR?=bin
 
 # This flag is used only for csi-client and windows.
 # TODO: Unify VERSION with STAGINGIMAGE
@@ -57,11 +60,11 @@ image:
 # STAGINGVERSION may contain multiple tags (e.g. canary, vX.Y.Z etc). Use one of the tags
 # for setting the driver version variable. For convenience we are using the first value.
 driver:
-	mkdir -p bin
+	mkdir -p ${BINDIR}
 	{                                                                                                                                 \
 	set -e ;                                                                                                                          \
 	for i in $(STAGINGVERSION) ; do                                                                                                   \
-		CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-X main.version='"$${i}"' -extldflags "-static"' -o bin/${DRIVERBINARY} ./cmd/; \
+		CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-X main.version='"$${i}"' -extldflags "-static"' -o ${BINDIR}/${DRIVERBINARY} ./cmd/; \
 		break;                                                                                                                          \
 	done ;                                                                                                                            \
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gcp-filestore-push-images/1371882741854900224: make driver is building the binary in ```/home/prow/go/src/github.com/kubernetes-sigs/gcp-filestore-csi-driver```, but the final COPY command
Step 14/17 : COPY --from=builder /go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/${DRIVERBINARY} /${DRIVERBINARY}
COPY failed: stat /var/lib/docker/overlay2/7fea248a42aa55bc591ada90ab9b6fec0fca20f83bb6a8348c358ce2eb31c791/merged/go/src/sigs.k8s.io/gcp-filestore-csi-driver/bin/gcp-filestore-csi-driver: no such file or directory

is using a /go/src from the host

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
