### PR TITLE
setup STAGINGVERSION when calling make driver from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@
 FROM golang:1.14.4 as builder
 WORKDIR /go/src/sigs.k8s.io/gcp-filestore-csi-driver
 ADD . .
-RUN make driver BINDIR=/bin
+ARG TAG=latest
+RUN make driver BINDIR=/bin GCP_FS_CSI_STAGING_VERSION=${TAG}
 
 # Install nfs packages
 FROM launcher.gcr.io/google/debian9 as deps

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ $(info GIT_TAG is $(GIT_TAG))
 $(info PWD is $(PWD))
 
 # A space-separated list of image tags under which the current build is to be pushed.
-# Determined dynamically.
+# Note: For Cloud build jobs, build-image-and-push make rule is the entry point with PULL_BASE_REF initialized.
+# PULL_BASE_REF is plumbed in to the docker build as a TAG, and this is used to setup GCP_FS_CSI_STAGING_VERSION.
 STAGINGVERSION=
 ifdef GCP_FS_CSI_STAGING_VERSION
 	STAGINGVERSION=${GCP_FS_CSI_STAGING_VERSION}
@@ -52,7 +53,7 @@ image:
 		{                                                                   \
 		set -e ;                                                            \
 		for i in $(STAGINGVERSION) ;                                        \
-			do docker build --build-arg DRIVERBINARY=$(DRIVERBINARY) -t $(STAGINGIMAGE):$${i} .; \
+			do docker build --build-arg DRIVERBINARY=$(DRIVERBINARY) --build-arg TAG=$(STAGINGVERSION) -t $(STAGINGIMAGE):$${i} .; \
 		done ;                                                              \
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This is another attempt to fix the GCB build failure as seen in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gcp-filestore-push-images/1371964232056180736

Capturing the call flow for GCB which caused the failure:
1. [cloudbuild.yaml](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/cloudbuild.yaml) triggers make build-image-and-push (with env variables - GIT_TAG=${_GIT_TAG}, PULL_BASE_REF=${_PULL_BASE_REF}, PROJECT=${_STAGING_PROJECT})
2.  This triggers rule for image in [Makefile](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/Makefile#L51). In this call to make, the PULL_BASE_REF is available as can be seen in the logs above.
3. This triggers docker build. one of the steps is to build the driver by calling [make driver](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/Dockerfile#L19). In this call, PULL_BASE_REF is not available, and calls [generate_image_tags](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/build/generate_image_tags.sh). Since PULL_BASE_REF is not initialized, git rev-list is called to find a tag. However in cloudbuild only downloads the source, and not the git info. Hence this call fails as seen in ```fatal: not a git repository (or any of the parent directories): .git```
4. Since STAGINGVERSION is empty, the for loop ```for i in $(STAGINGVERSION) ; ``` is never executed for the make driver call, hence there is no binary created.
5. Docker build thus fails in the ```COPY --from=builder /bin/${DRIVERBINARY} /${DRIVERBINARY}``` step.

Fix:
Fix is to pass the information to initialize STAGINGVERSION in the make driver call, so that `go build` command is executed.

Testing:
to mock the GCB build env, I removed the .git (so that no git commands would work) and tried out following to mock the cloudbuild.yaml trigger:
PROJECT=mattcary-saikatroyc-test PULL_BASE_REF=v0.4.0-rc1 make build-image-and-push and verfied that git information is not fetched and binary is created as expected and COPY steps succeeds.

some snippet from the testing
```
PULL_BASE_REF is v0.4.0-rc1
GIT_TAG is 
PWD is /usr/local/google/home/saikatroyc/go/src/sigs.k8s.io/gcp-filestore-csi-driver
STAGINGVERSION is v0.4.0-rc1
STAGINGIMAGE is gcr.io/mattcary-saikatroyc-test/gcp-filestore-csi-driver
{                                                                   \
	set -e ;                                                            \
	for i in v0.4.0-rc1 ;                                        \
		do docker build --build-arg DRIVERBINARY=gcp-filestore-csi-driver --build-arg TAG=v0.4.0-rc1 -t gcr.io/mattcary-saikatroyc-test/gcp-filestore-csi-driver:${i} .; \
	done ;                                                              \
	}

Step 2/18 : WORKDIR /go/src/sigs.k8s.io/gcp-filestore-csi-driver
...
Step 3/18 : ADD . .
...
Step 4/18 : ARG TAG=latest
...
Step 5/18 : RUN make driver BINDIR=/bin GCP_FS_CSI_STAGING_VERSION=${TAG}
...
PULL_BASE_REF is 
GIT_TAG is 
PWD is /go/src/sigs.k8s.io/gcp-filestore-csi-driver
STAGINGVERSION is v0.4.0-rc1
STAGINGIMAGE is gcr.io//gcp-filestore-csi-driver
mkdir -p /bin
{                                                                                                                                 \
set -e ;                                                                                                                          \
for i in v0.4.0-rc1 ; do                                                                                                   \
	CGO_ENABLED=0 go build -mod=vendor -a -ldflags '-X main.version='"${i}"' -extldflags "-static"' -o /bin/gcp-filestore-csi-driver ./cmd/; \
	break;                                                                                                                          \
done ;                                                                                                                            \
}
...
Step 15/18 : COPY --from=builder /bin/${DRIVERBINARY} /${DRIVERBINARY}
...
Step 16/18 : RUN true
...
Step 17/18 : COPY deploy/kubernetes/nfs_services_start.sh /nfs_services_start.sh
...
Step 18/18 : ENTRYPOINT ["/gcp-filestore-csi-driver"]
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix GCB builds
```
