### PR TITLE
Update stable overlays to 0.4.0 driver image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dynamically created and mounted by workloads.
 ## Project Status
 Status: Beta
 
-Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v0.3.1`
+Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v0.4.0`
 
 Also see [known issues](KNOWN_ISSUES.md) and [CHANGELOG](CHANGELOG.md).
 
@@ -26,6 +26,7 @@ The following table captures the compatibility matrix of the core filestore driv
 | --------------------------------------- | ---- | ---- | ---- | ----- |
 | v0.2.0 (alpha)                          | yes  |  no  |  no  |  no   |
 | v0.3.1 (beta)                           | no   |  yes |  yes |  yes  |
+| v0.4.0 (beta)                           | no   |  yes |  yes |  yes  |
 | master                                  | no   |  yes |  yes |  yes  |
 
 The manifest bundle which captures all the driver components (driver pod which includes the containers csi-external-provisioner, csi-external-resizer, csi-external-snapshotter, gcp-filestore-driver, csi-driver-registrar;

--- a/deploy/kubernetes/images/stable-1-16/image.yaml
+++ b/deploy/kubernetes/images/stable-1-16/image.yaml
@@ -31,5 +31,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.3.1"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/stable-1-17/image.yaml
+++ b/deploy/kubernetes/images/stable-1-17/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.3.1"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/stable-1-18/image.yaml
+++ b/deploy/kubernetes/images/stable-1-18/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.3.1"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/stable-1-19/image.yaml
+++ b/deploy/kubernetes/images/stable-1-19/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.3.1"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.3.1"
+  newTag: "v0.4.0"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Update container `gcp-filestore-driver` image to v0.4.0 for stable-1-16,  stable-1-17, stable-1-18, stable-1-19, stable-master overlays

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Next steps is to cherry pick this PR to release-0.4, create a release tag v0.4.0, and then add the new image to promoter (k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
