### PR TITLE
Update prow rc images to use v0.4.0 driver image

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
@@ -31,6 +31,5 @@ metadata:
   name: imagetag-gce-fs-driver-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.4.0-rc2"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
@@ -40,6 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.4.0-rc2"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
@@ -40,6 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.4.0-rc2"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
@@ -40,6 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.4.0-rc2"
+  newTag: "v0.4.0"
 ---

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -40,6 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.4.0-rc2"
+  newTag: "v0.4.0"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR will ensure that the internal prow staging rc jobs now use the v0.4.0 driver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
