### PR TITLE
Enable leader election and metrics endpoint

### DIFF
--- a/deploy/kubernetes/base/controller/controller.yaml
+++ b/deploy/kubernetes/base/controller/controller.yaml
@@ -30,6 +30,26 @@ spec:
             - "--timeout=250s"
             - "--feature-gates=Topology=true"
             - "--extra-create-metadata"
+            - "--http-endpoint=:22021"
+            - "--leader-election-namespace=$(FILESTORECSI_NAMESPACE)"
+            - "--leader-election"
+          env:
+            - name: FILESTORECSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 22021
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz/leader-election
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 20
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -39,6 +59,26 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--timeout=120s"
+            - "--http-endpoint=:22022"
+            - "--leader-election"
+            - "--leader-election-namespace=$(FILESTORECSI_NAMESPACE)"
+          env:
+            - name: FILESTORECSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 22022
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz/leader-election
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 20
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -48,6 +88,17 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--timeout=300s"
+            - "--metrics-address=:22023"
+            - "--leader-election"
+            - "--leader-election-namespace=$(FILESTORECSI_NAMESPACE)"
+          env:
+            - name: FILESTORECSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 22023
+              name: metrics
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/kubernetes/base/controller/setup_cluster.yaml
+++ b/deploy/kubernetes/base/controller/setup_cluster.yaml
@@ -200,3 +200,33 @@ subjects:
     name: gcp-filestore-csi-node-sa
     namespace: gcp-filestore-csi-driver
 ---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-leaderelection-role
+  namespace: gcp-filestore-csi-driver
+  labels:
+    k8s-app: gcp-filestore-csi-driver
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gcp-filestore-csi-leaderelection-binding
+  namespace: gcp-filestore-csi-driver
+  labels:
+    k8s-app: gcp-filestore-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: gcp-filestore-csi-controller-sa
+    namespace: gcp-filestore-csi-driver
+roleRef:
+  kind: Role
+  name: gcp-filestore-csi-leaderelection-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/overlays/stable-1-16/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-16/kustomization.yaml
@@ -8,5 +8,12 @@ resources:
 patchesStrategicMerge:
 - no_snapshotter_sidecar.yaml
 - no_snapshotter_roles.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: gcp-filestore-csi-controller
+  path: metrics_leaderelection_endpoint.yaml
 transformers:
 - ../../images/stable-1-16

--- a/deploy/kubernetes/overlays/stable-1-16/metrics_leaderelection_endpoint.yaml
+++ b/deploy/kubernetes/overlays/stable-1-16/metrics_leaderelection_endpoint.yaml
@@ -1,0 +1,16 @@
+# for csi-external-provisioner
+- op: replace
+  path: /spec/template/spec/containers/0/args/5
+  value: "--metrics-address=:22021"
+- op: replace
+  path: /spec/template/spec/containers/0/args/6
+  value: "--enable-leader-election"
+- op: replace
+  path: /spec/template/spec/containers/0/args/7
+  value: "--leader-election-type=leases"
+- op: remove
+  path: /spec/template/spec/containers/0/env/0
+- op: remove
+  path: /spec/template/spec/containers/0/ports
+- op: remove
+  path: /spec/template/spec/containers/0/livenessProbe


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Enabled metrics and leader election for sidecars.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
For 4.x snapshotter, http-endpoint flag is not yet enabled because of bug https://github.com/kubernetes-csi/external-snapshotter/issues/492

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable leader election and metrics endpoint for sidecars
```
