### PR TITLE
Tweak documentation

### DIFF
--- a/docs/kubernetes/pre-provisioned-pv.md
+++ b/docs/kubernetes/pre-provisioned-pv.md
@@ -18,6 +18,10 @@ If you have not already pre-provisioned a filestore instance on GCP you can do t
 kubectl apply -f ./examples/kubernetes/sc-latebind.yaml
 ```
 
+This storageclass will not bind a PVC to a PV until there is a pod created using
+the PVC. If you wish to bind the PV and PVC immediately on PVC creation, change
+`volumeBindingMode` to `Immediate`.
+
 2. Create example Persistent Volume
 
 **Note:** The `volumeHandle` should be updated

--- a/examples/kubernetes/pre-provision/preprov-pv.yaml
+++ b/examples/kubernetes/pre-provision/preprov-pv.yaml
@@ -5,15 +5,15 @@ metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: filestore.csi.storage.gke.io
 spec:
-  storageClassName: "csi-filestore"
+  storageClassName: csi-filestore
   capacity:
     storage: 1Ti
   accessModes:
     - ReadWriteMany
-  persistentVolumeReclaimPolicy: "Delete"
-  volumeMode: "Filesystem"
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
   csi:
-    driver: "filestore.csi.storage.gke.io"
+    driver: filestore.csi.storage.gke.io
     # Modify this to use the zone, filestore instance and share name.
     volumeHandle: "modeInstance/<zone>/<filestore-instance-name>/<filestore-share-name>"
     volumeAttributes:


### PR DESCRIPTION
This is a low-priority PR.

Tweak documentation, particularly for pre-provisioned PVs.

Using a retain reclaim policy is much safer and should probably be the default, especially for pre-provisioned instances. (I'm assuming that a delete policy will actually delete the instance when the PV is killed?)

Also changing the binding mode. I think that the common case is going to be to create the PVC at the same time as the PV, so it will be best to bind immediately to prevent problems if, eg, another PV with the same storageclass is created in the future.

/kind documentation
```release-note
None
```
