### PR TITLE
Serialize volume operations for a given volume and return appropriate error codes

### DIFF
--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/mount"
 	cloud "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider"
 	metadataservice "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
 
 type GCFSDriverConfig struct {
@@ -100,6 +101,7 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 			driver:      driver,
 			fileService: config.Cloud.File,
 			cloud:       config.Cloud,
+			volumeLocks: util.NewVolumeLocks(),
 		})
 	}
 

--- a/pkg/util/volume_lock.go
+++ b/pkg/util/volume_lock.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	VolumeOperationAlreadyExistsFmt = "An operation with the given volume key %s already exists"
+)
+
+// VolumeLocks implements a map with atomic operations. It stores a set of all volume IDs
+// with an ongoing operation.
+type VolumeLocks struct {
+	locks sets.String
+	mux   sync.Mutex
+}
+
+func NewVolumeLocks() *VolumeLocks {
+	return &VolumeLocks{
+		locks: sets.NewString(),
+	}
+}
+
+// TryAcquire tries to acquire the lock for operating on volumeID and returns true if successful.
+// If another operation is already using volumeID, returns false.
+func (vl *VolumeLocks) TryAcquire(volumeID string) bool {
+	vl.mux.Lock()
+	defer vl.mux.Unlock()
+	if vl.locks.Has(volumeID) {
+		return false
+	}
+	vl.locks.Insert(volumeID)
+	return true
+}
+
+func (vl *VolumeLocks) Release(volumeID string) {
+	vl.mux.Lock()
+	defer vl.mux.Unlock()
+	vl.locks.Delete(volumeID)
+}


### PR DESCRIPTION
1. Use mutex for volume ops locking
2. Use appropriate error codes for expected long running ops

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Filestore operations are long running by default. We need to differentiate expected operations from internal errors to avoid false positives in SLO breach. This PR ensures that for expected filestore operations DeadlineExceeded is returned.
Further, volume locking is implemented in order to serialize volume operations in controller and node.
- For a given volume ID, create/delete/createsnapshot is serialized.
- For a given volume ID, node stage/unstage operation is serialized
- Node publish/unpublish operations are serialized at a targetPath key, since we want to node publish operations to work in parallel, for a given staged volume.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Test manually by reducing the caller timeout flags of csi-provisioner and csi-snapshotter sidecar [this](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/deploy/kubernetes/base/controller/controller.yaml#L30) and [this](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/deploy/kubernetes/base/controller/controller.yaml#L90) to very small value like 20 seconds, and checked that appropriate deadline exceeded errors are returned during filestore instance provision/delete and create/delete snapshot ops.
Also tested with deployment of ~50 replicas scheduled on a single node, to ensure node publish work in parallel for each pod.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Serialize volume operations for a given volume and return appropriate error codes
```
