### PR TITLE
Fix roles needed to deploy the driver, and use v1 csidriver object for 1.20+ clusters

### DIFF
--- a/deploy/kubernetes/overlays/stable-master/fsgrouppolicy.yaml
+++ b/deploy/kubernetes/overlays/stable-master/fsgrouppolicy.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: "/spec/fsGroupPolicy"
   value: File
+- op: replace
+  path: "/apiVersion"
+  value: storage.k8s.io/v1

--- a/deploy/project_setup.sh
+++ b/deploy/project_setup.sh
@@ -17,7 +17,6 @@ gcloud iam service-accounts delete "$GCFS_IAM_NAME" --quiet || true
 
 gcloud iam service-accounts create "$GCFS_SA_NAME"
 gcloud projects add-iam-policy-binding "$PROJECT" --member serviceAccount:"$GCFS_IAM_NAME" --role roles/file.editor
-gcloud projects add-iam-policy-binding "$PROJECT" --member serviceAccount:"$GCFS_IAM_NAME" --role roles/editor
 
 # Enable Cloud Filestore API for this project.
 gcloud services enable file.googleapis.com


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
1. Remove editor role, as file.editor role is sufficient for filestore csi driver operations.
2.  update v1 csi driver for stable-master overlays 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
1. tested locally by recreating the SA with the updated project_setup.sh script and verify roles.
```
- members:
  - serviceAccount:gcp-filestore-csi-driver-sa@mattcary-saikatroyc-test.iam.gserviceaccount.com
  role: roles/file.editor
```
2. Deploy the driver in a 1.20 cluster and verify driver bring up works with the v1 csidriver object.
3. Basic provisioning/delete/snapshot manual test.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix roles needed to deploy the driver, and use v1 csidriver object for 1.20+ clusters
```
