### PR TITLE
Cherrypick #135 - Skip statd service on node startup if it's already running

### DIFF
--- a/deploy/kubernetes/nfs_services_start.sh
+++ b/deploy/kubernetes/nfs_services_start.sh
@@ -5,6 +5,19 @@ set -o errexit
 trap "{ exit 0 }" TERM
 
 service rpcbind start
-service nfs-common start
+
+# If statd is already running, for example becuase of an existing nfs mount, we will fail
+# to service nfs-common start. If we successfully query the statd service (rpc program
+# number 100024), that means it's running, and we don't need to start it. This command
+# is put in /etc/default/nfs-common as the NEED_STATD variable must be set there.
+
+if rpcinfo -T udp 127.0.0.1 100024; then
+  echo statd already running
+  echo NEED_STATD=no >> /etc/default/nfs-common
+else
+  echo no statd found
+fi
+
+service nfs-common start  
 
 sleep infinity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skip statd service on node startup if it's already running
```
