### PR TITLE
fixed issue with unability to recognize gce-region flag is set

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -132,7 +132,12 @@ func main() {
 	}
 
 	ensureVariable(testFocus, true, "test-focus is a required flag")
-	ensureVariable(gceZone, true, "One of gce-zone or gce-region must be set")
+
+	if len(*gceRegion) != 0 {
+		ensureVariable(gceZone, false, "gce-zone and gce-region cannot both be set")
+	} else {
+		ensureVariable(gceZone, true, "One of gce-zone or gce-region must be set")
+	}
 
 	if !*bringupCluster {
 		ensureVariable(kubeFeatureGates, false, "kube-feature-gates set but not bringing up new cluster")


### PR DESCRIPTION


**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
test failure in prow

**Which issue(s) this PR fixes**:
test failure [here](https://prow-gob.gcpnode.com/view/gs/gob-prow/logs/periodic-gke-pd-csi-driver-k8s-integration-preview-regional-test-env/1414991095246360576) caused by test script's inability to recognize `gce-region` flag being set


```release-note
None
```
