### PR TITLE
fixed issue with clusterUpGKE when release channel is set

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -324,8 +324,9 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, imageType string, use
 			request.Cluster.InitialClusterVersion = *gkeClusterVer
 		} else {
 			request.Cluster.ReleaseChannel = &container.ReleaseChannel{Channel: *gkeReleaseChannel}
-			// release channel based GKE clusters require autorepair to be enabled.
+			// release channel based GKE clusters require autorepair and autoupgrade to be enabled.
 			request.Cluster.NodePools[0].Management = &container.NodeManagement{AutoRepair: true}
+			request.Cluster.NodePools[0].Management.AutoUpgrade = true
 		}
 
 		if isVariableSet(gkeNodeVersion) {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
test failure in prow

**Which issue(s) this PR fixes**:
test failure [here](https://prow-gob.gcpnode.com/view/gs/gob-prow/logs/periodic-gcp-filestore-csi-driver-k8s-integration-staging-driver-rapid-gke-poc/1414975750053826560) caused by auto-upgrade required when gke release channel is set


```release-note
None
```