### PR TITLE
support for enterprise tier filestore instance

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -88,6 +88,8 @@ const (
 
 	// Patch update masks
 	fileShareUpdateMask = "file_shares"
+
+	enterpriseTier = "enterprise"
 )
 
 var _ Service = &gcfsServiceManager{}
@@ -153,6 +155,11 @@ func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Serv
 }
 
 func (manager *gcfsServiceManager) CreateInstanceFromBackupSource(ctx context.Context, obj *ServiceInstance, sourceSnapshotId string) (*ServiceInstance, error) {
+	// enterprise tier Filestore does not yet support Backup
+	if obj.Tier == enterpriseTier {
+		return nil, fmt.Errorf("invalid argument: enterprise tier Filestore does not support Backup yet")
+	}
+
 	instance := &filev1beta1.Instance{
 		Tier: obj.Tier,
 		FileShares: []*filev1beta1.FileShareConfig{

--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -88,8 +88,6 @@ const (
 
 	// Patch update masks
 	fileShareUpdateMask = "file_shares"
-
-	enterpriseTier = "enterprise"
 )
 
 var _ Service = &gcfsServiceManager{}
@@ -155,11 +153,6 @@ func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Serv
 }
 
 func (manager *gcfsServiceManager) CreateInstanceFromBackupSource(ctx context.Context, obj *ServiceInstance, sourceSnapshotId string) (*ServiceInstance, error) {
-	// enterprise tier Filestore does not yet support Backup
-	if obj.Tier == enterpriseTier {
-		return nil, fmt.Errorf("invalid argument: enterprise tier Filestore does not support Backup yet")
-	}
-
 	instance := &filev1beta1.Instance{
 		Tier: obj.Tier,
 		FileShares: []*filev1beta1.FileShareConfig{

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -37,6 +37,7 @@ const (
 	newInstanceVolume       = "vol1"
 
 	defaultTier    = "standard"
+	enterpriseTier = "enterprise"
 	defaultNetwork = "default"
 
 	// Keys for Topology.
@@ -377,6 +378,13 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 		// Cloud API will validate these
 		case paramTier:
 			tier = v
+			if tier == enterpriseTier {
+				region, err := util.GetRegionFromZone(location)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get region from zone %s: %v", location, err)
+				}
+				location = region
+			}
 		case paramNetwork:
 			network = v
 		// Ignore the cidr flag as it is not passed to the cloud provider

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -121,6 +121,9 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 
 	sourceSnapshotId := ""
 	if req.GetVolumeContentSource() != nil {
+		if newFiler.Tier == enterpriseTier {
+			return nil, status.Error(codes.InvalidArgument, "Enterprise tier Filestore does not support Backup yet")
+		}
 		if req.GetVolumeContentSource().GetVolume() != nil {
 			return nil, status.Error(codes.InvalidArgument, "Unsupported volume content source")
 		}

--- a/pkg/csi_driver/controller_unimpl.go
+++ b/pkg/csi_driver/controller_unimpl.go
@@ -48,5 +48,5 @@ func (s *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnaps
 }
 
 func (s *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControllerExpandVolume unsupported")
+	return nil, status.Error(codes.Unimplemented, "ControllerGetVolume unsupported")
 }


### PR DESCRIPTION


**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
the new enterprise tier filestore instance needs some special attention on creation - it is regional instead of zonal


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
