### PR TITLE
Skip topology tests for filestore csi driver

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -25,6 +25,3 @@ DriverInfo:
   SupportedSizeRange:
     Min: {{.MinimumVolumeSize}}
     Max: 64Ti
-  TopologyKeys:
-    - topology.gke.io/zone
-  NumAllowedTopologies: {{.NumAllowedTopologies}}

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -64,7 +64,6 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		"exec",
 		"RWX",
 		"multipods",
-		"topology",
 		"controllerExpansion",
 	}
 
@@ -103,7 +102,6 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 	}
 
 	minimumVolumeSize := "1Ti"
-	numAllowedTopologies := 1
 	// Filestore instance takes in the order of minutes to be provisioned, and with dynamic provisioning (WaitForFirstCustomer policy),
 	// some e2e tests need a longer pod start timeout.
 	timeouts := map[string]string{
@@ -111,13 +109,12 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		podStartTimeoutKey:       podStartTimeout,
 	}
 	params := driverConfig{
-		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
-		StorageClass:         storageClassFile[:strings.LastIndex(storageClassFile, ".")],
-		SnapshotClassFile:    absSnapshotClassFilePath,
-		Capabilities:         caps,
-		MinimumVolumeSize:    minimumVolumeSize,
-		NumAllowedTopologies: numAllowedTopologies,
-		Timeouts:             timeouts,
+		StorageClassFile:  filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
+		StorageClass:      storageClassFile[:strings.LastIndex(storageClassFile, ".")],
+		SnapshotClassFile: absSnapshotClassFilePath,
+		Capabilities:      caps,
+		MinimumVolumeSize: minimumVolumeSize,
+		Timeouts:          timeouts,
 	}
 
 	// Write config file


### PR DESCRIPTION
Filestore instances can be accessible from any zone in a k8s cluster, as
long as nodes are in the same VPC.
Filestore CSI driver honors the [CreateVolumeRequest. accessibility_requirements](https://github.com/container-storage-interface/spec/blob/release-1.3/csi.proto#L345), and deploys a standard/premium tier in the given zone. However since the instance can be accessible from any zone, it does not place any accesible topology restriction in the CreateVolumeResponse. This means, the PV.NodeAffinity [will not be set](https://github.com/kubernetes-csi/external-provisioner/blob/release-2.2/pkg/controller/controller.go#L827), and thus the scheduler does not take into account any node affinity while scheduling pods.

The topology tests expects the pod to be scheduled in the accesible topology is not a valid test case for filestore. 
The test flakes whenever the pod is scheduled in a zone, outside the allowed topolgy list.

Instead, we have created a task to create an internal test, which tests filestore instance directly and verify the zone where it has been created.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
