### PR TITLE
Adding step to clone repository at specific path used by cluster-setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Note that non-default networks require extra [firewall setup](https://cloud.goog
 
 ## Deploying the Driver
 
+* Clone the repositry in cloudshell using following commands
+
+```
+mkdir -p $GOPATH/src/sigs.k8s.io
+cd $GOPATH/src/sigs.k8s.io
+git clone https://github.com/kubernetes-sigs/gcp-filestore-csi-driver.git
+```
+
 * Set up a service account with appropriate role binds, and download a service account key. This
   service account will be used by the driver to provision Filestore instances and otherwise access
   GCP APIs. This can be done by running `./deploy/project_setup.sh` and pointing to a directory to


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR ensures that user clone the repository in right path.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Without cloning repository on defined path, user will have following error
```
./deploy/kubernetes/../common.sh: line 20: /home/user/gopath:/google/gopath/src/sigs.k8s.io/gcp-filestore-csi-driver/deploy/kubernetes/install_kustomize.sh: No such file or directory`
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
