### PR TITLE
Check pending update operation for volume expand

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -189,6 +189,10 @@ func (manager *fakeServiceManager) CreateInstanceFromBackupSource(ctx context.Co
 	return instance, nil
 }
 
+func (m *fakeServiceManager) HasOperations(ctx context.Context, obj *ServiceInstance, operationType string, done bool) (bool, error) {
+	return false, nil
+}
+
 func notFoundError() *googleapi.Error {
 	return &googleapi.Error{
 		Errors: []googleapi.ErrorItem{
@@ -227,4 +231,8 @@ func (m *fakeBlockingServiceManager) DeleteInstance(ctx context.Context, obj *Se
 	m.OperationUnblocker <- execute
 	<-execute
 	return m.fakeServiceManager.DeleteInstance(ctx, obj)
+}
+
+func (m *fakeBlockingServiceManager) HasOperations(ctx context.Context, obj *ServiceInstance, operationType string, done bool) (bool, error) {
+	return false, nil
 }

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -458,18 +458,42 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 
 	filer, _, err := getFileInstanceFromID(volumeID)
 	if err != nil {
-		glog.Errorf("failed to get instance for volumeID %v expansion, error: %v", volumeID, err)
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	filer.Project = s.config.cloud.Project
+	filer, err = s.config.fileService.GetInstance(ctx, filer)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if filer.State != "READY" {
+		return nil, fmt.Errorf("Volume %q is not yet ready, current state %q", volumeID, filer.State)
+	}
+
+	if util.BytesToGb(reqBytes) <= util.BytesToGb(filer.Volume.SizeBytes) {
+		glog.Infof("Controller expand volume succeeded for volume %v, existing size(bytes): %v", volumeID, filer.Volume.SizeBytes)
+		return &csi.ControllerExpandVolumeResponse{
+			CapacityBytes:         filer.Volume.SizeBytes,
+			NodeExpansionRequired: false,
+		}, nil
+	}
+
+	hasPendingOps, err := s.config.fileService.HasOperations(ctx, filer, "update", false /* done */)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if hasPendingOps {
+		return nil, status.Error(codes.DeadlineExceeded, fmt.Sprintf("Update operation ongoing for volume %v", volumeID))
+	}
+
 	filer.Volume.SizeBytes = reqBytes
 	newfiler, err := s.config.fileService.ResizeInstance(ctx, filer)
 	if err != nil {
-		glog.Errorf("failed to resize volumeID %v, error: %v", volumeID, err)
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	glog.Infof("Controller expand volume succeeded for volume %v, new size(bytes): %v", volumeID, newfiler.Volume.SizeBytes)
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         newfiler.Volume.SizeBytes,
 		NodeExpansionRequired: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When resize operation is in progress in filestore, avoid sending more requests, as these will be reject by filestore `googleapi: Error 409: unable to queue the operation, aborted`. When filestore instance resize is in progress, the instance itself does not indicate the state of patching. So the alternative is to check for any pending patch operation of the given filestore instance and return a known error code (DeadlineExceeded). The csi resizer keeps retrying, but since we will return a known error code, the cluster happiness will not be impacted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
1. Reordered the sequence of GET instance, if instance size < requested, only then list pending operations, and if no pending operation found, proceed with resize call.
2. list API does not handle filter operation of metadata.target so, the filtering has to be done similar to how gcloud handles commands like this.
```
gcloud filestore operations list --filter="metadata.target:projects/mattcary-saikatroyc-test/locations/us-central1-a/instances/pvc-6619818e-4001-4f59-9517-24b508e127b7 AND done=true" --log-http
```
The filter is done after receiving the results:
```
gcloud filestore operations list --filter="metadata.target:projects/mattcary-saikatroyc-test/locations/us-central1-a/instances/pvc-6619818e-4001-4f59-9517-24b508e127b7 AND done=true" --log-http
=======================
==== request start ====
uri: https://file.googleapis.com/v1/projects/mattcary-saikatroyc-test/locations/-/operations?alt=json&pageSize=100
method: GET
== headers start ==
b'X-Goog-User-Project': b'mattcary-saikatroyc-test'
b'accept': b'application/json'
b'accept-encoding': b'gzip, deflate'
b'authorization': --- Token Redacted ---
b'content-length': b'0'
b'user-agent': b'google-cloud-sdk gcloud/351.0.0 command/gcloud.filestore.operations.list invocation-id/6c54443b3d0a43cab4edcdc01cd68b03 environment/GCE environment-version/None interactive/True from-script/False python/3.9.2 term/xterm-256color (Linux 5.10.40-1rodete2-amd64)'
== headers end ==
== body start ==

== body end ==
==== request end ====
```
sample response:
```
---- response start ----
status: 200
-- headers start --
Cache-Control: private
Content-Encoding: gzip
Content-Type: application/json; charset=UTF-8
Date: Fri, 06 Aug 2021 23:05:04 GMT
Server: ESF
Transfer-Encoding: chunked
Vary: Origin, X-Origin, Referer
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
-- headers end --
-- body start --
{
  "operations": [
    {
      "name": "projects/mattcary-saikatroyc-test/locations/us-central1/operations/operation-1628283478079-5c8ea4a4df86e-5d5bba42-97ee17d4",
      "metadata": {
        "@type": "type.googleapis.com/google.cloud.common.OperationMetadata",
        "createTime": "2021-08-06T20:57:58.911872836Z",
        "endTime": "2021-08-06T21:10:52.607265436Z",
        "target": "projects/mattcary-saikatroyc-test/locations/us-central1/instances/pvc-c8834303-ba7d-41fa-add1-42a3657ad58a",
        "verb": "create",
        "cancelRequested": false,
        "apiVersion": "v1beta1"
      },
      "done": true,
      "response": {
        "@type": "type.googleapis.com/google.cloud.filestore.v1beta1.Instance",
        "name": "projects/mattcary-saikatroyc-test/locations/us-central1/instances/pvc-c8834303-ba7d-41fa-add1-42a3657ad58a",
        "state": "READY",
        "createTime": "2021-08-06T20:57:58.879014787Z",
        "tier": "ENTERPRISE",
        "labels": {
          "storage_gke_io_created-by": "filestore_csi_storage_gke_io",
          "kubernetes_io_created-for_pv_name": "pvc-c8834303-ba7d-41fa-add1-42a3657ad58a",
          "kubernetes_io_created-for_pvc_name": "podpvc",
          "kubernetes_io_created-for_pvc_namespace": "default"
        },
        "fileShares": [
          {
            "name": "vol1",
            "capacityGb": "1024"
          }
        ],
        "networks": [
          {
            "network": "default",
            "modes": [
              "MODE_IPV4"
            ],
            "reservedIpRange": "172.16.0.0/24",
            "ipAddresses": [
              "172.16.0.2"
            ]
          }
        ]
      }
    },
```

3. Manual Testing:
reduced the timeout for resizer to a very small value 2 seconds, and verified that either aborted or deadline exceeded is returned while the patch operation is in progress.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check pending update operation for volume expand
```
