### PR TITLE
remove the hard-coded 29 for ipRangeSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ volume. Customizable parameters for volume creation include:
 | ---------------   | ----------------------- |-----------                             | ----------- |
 | tier              | "standard"<br>"premium"<br>"enterprise" | "standard"                             | storage performance tier |
 | network           | string                  | "default"                              | VPC name |
-| reserved-ipv4-cidr| string		              | ""                                     | CIDR range to allocate Filestore IP Ranges from.<br>The CIDR must be large enough to accommodate multiple Filestore IP Ranges of /29 each |
+| reserved-ipv4-cidr| string		              | ""                                     | CIDR range to allocate Filestore IP Ranges from.<br>The CIDR must be large enough to accommodate multiple Filestore IP Ranges of /29 each, /24 if enterprise tier is used |
 
 For Kubernetes clusters, these parameters are specified in the StorageClass.
 

--- a/pkg/util/ip_def.go
+++ b/pkg/util/ip_def.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	// the ipRangeSize for Filestore instances
+	IpRangeSize = 29
+
+	// the ipRangeSize for enterprise tier Filestore instances
+	IpRangeSizeEnterprise = 24
+)


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
cidr range size was hardcoded, and enterprise tier filestore needs 24 instead of 29

**Special notes for your reviewer:**
manual tests by providing `reserved-ipv4-cidr` in a enterprise tier filestore csi storageClass and verified that the provision succeeded.

```release-note
NONE
```
