### PR TITLE
Update stable overlays image to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This driver allows volumes backed by Google Cloud Filestore instances to be
 dynamically created and mounted by workloads.
 
 ## Project Status
-Status: Beta
+Status: GA
 
-Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v0.6.1`
+Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v1.0.0`
 
 Also see [known issues](KNOWN_ISSUES.md) and [CHANGELOG](CHANGELOG.md).
 

--- a/deploy/kubernetes/images/stable-1-17/image.yaml
+++ b/deploy/kubernetes/images/stable-1-17/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.6.1"
+  newTag: "v1.0.0"
 ---

--- a/deploy/kubernetes/images/stable-1-18/image.yaml
+++ b/deploy/kubernetes/images/stable-1-18/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.6.1"
+  newTag: "v1.0.0"
 ---

--- a/deploy/kubernetes/images/stable-1-19/image.yaml
+++ b/deploy/kubernetes/images/stable-1-19/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.6.1"
+  newTag: "v1.0.0"
 ---

--- a/deploy/kubernetes/images/stable-1-20/image.yaml
+++ b/deploy/kubernetes/images/stable-1-20/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.6.1"
+  newTag: "v1.0.0"
 ---

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v0.6.1"
+  newTag: "v1.0.0"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Changes to stable-* overlays to use to be released 1.0.0 filestore csi driver image

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
The prow [run](https://prow-gob.gcpnode.com/view/gcs/gob-prow/logs/periodic-gcp-fs-csi-driver-k8s-integration-staging-rc-master/1433927104726044672) with staging image v1.0.0-rc1 has passed.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update stable overlays image to 1.0.0
```
