### PR TITLE
new storageclass and increase pvc timeout for enterprise tier prow test

### DIFF
--- a/test/k8s-integration/config/fs-sc-enterprise-default-network.yaml
+++ b/test/k8s-integration/config/fs-sc-enterprise-default-network.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-filestore-enterprise
+provisioner: filestore.csi.storage.gke.io
+parameters:
+  tier: enterprise
+volumeBindingMode: WaitForFirstConsumer

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -26,10 +26,12 @@ const (
 	testConfigDir      = "test/k8s-integration/config"
 	configTemplateFile = "test-config-template.in"
 	configFile         = "test-config.yaml"
+	enterpriseTier     = "enterprise"
 
 	// configurable timeouts for the k8s e2e testsuites.
-	podStartTimeout       = "600s"
-	claimProvisionTimeout = "600s"
+	podStartTimeout                 = "600s"
+	claimProvisionTimeout           = "600s"
+	enterpriseClaimProvisionTimeout = "1800s"
 
 	// These are keys for the configurable timeout map.
 	podStartTimeoutKey       = "PodStart"
@@ -107,6 +109,9 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 	timeouts := map[string]string{
 		claimProvisionTimeoutKey: claimProvisionTimeout,
 		podStartTimeoutKey:       podStartTimeout,
+	}
+	if strings.Contains(storageClassFile, enterpriseTier) {
+		timeouts[claimProvisionTimeoutKey] = enterpriseClaimProvisionTimeout
 	}
 	params := driverConfig{
 		StorageClassFile:  filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In order to run prow tests with enterprise tier storage-class, we need to have a storage-class and increase the provisioning timeout because enterprise tier pv takes ~20 min to provision.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
