### PR TITLE
increasing the minVolumeSize for premium tier for k8s integration test

### DIFF
--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -27,6 +27,7 @@ const (
 	configTemplateFile = "test-config-template.in"
 	configFile         = "test-config.yaml"
 	enterpriseTier     = "enterprise"
+	premiumTier        = "premium"
 
 	// configurable timeouts for the k8s e2e testsuites.
 	podStartTimeout                 = "600s"
@@ -104,6 +105,9 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 	}
 
 	minimumVolumeSize := "1Ti"
+	if strings.Contains(storageClassFile, premiumTier) {
+		minimumVolumeSize = "2.5Ti"
+	}
 	// Filestore instance takes in the order of minutes to be provisioned, and with dynamic provisioning (WaitForFirstCustomer policy),
 	// some e2e tests need a longer pod start timeout.
 	timeouts := map[string]string{


### PR DESCRIPTION


**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:
tests are failing because premium tier instances requires at least 2.5Ti

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
