### PR TITLE
enable dynamic provision with shared-vpc from service project

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -53,6 +53,7 @@ type Volume struct {
 
 type Network struct {
 	Name            string
+	ConnectMode     string
 	ReservedIpRange string
 	Ip              string
 }
@@ -124,18 +125,20 @@ func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Serv
 				Network:         obj.Network.Name,
 				Modes:           []string{"MODE_IPV4"},
 				ReservedIpRange: obj.Network.ReservedIpRange,
+				ConnectMode:     obj.Network.ConnectMode,
 			},
 		},
 		Labels: obj.Labels,
 	}
 
-	glog.V(4).Infof("Creating instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v, labels %v",
+	glog.V(4).Infof("Creating instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v, connectMode %v, labels %v",
 		obj.Name,
 		obj.Location,
 		betaObj.Tier,
 		betaObj.FileShares[0].CapacityGb,
 		betaObj.Networks[0].Network,
 		betaObj.Networks[0].ReservedIpRange,
+		betaObj.Networks[0].ConnectMode,
 		betaObj.Labels)
 	op, err := manager.instancesService.Create(locationURI(obj.Project, obj.Location), betaObj).InstanceId(obj.Name).Context(ctx).Do()
 	if err != nil {
@@ -169,19 +172,21 @@ func (manager *gcfsServiceManager) CreateInstanceFromBackupSource(ctx context.Co
 				Network:         obj.Network.Name,
 				Modes:           []string{"MODE_IPV4"},
 				ReservedIpRange: obj.Network.ReservedIpRange,
+				ConnectMode:     obj.Network.ConnectMode,
 			},
 		},
 		Labels: obj.Labels,
 		State:  obj.State,
 	}
 
-	glog.V(4).Infof("Creating instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v, labels %v backup source %v",
+	glog.V(4).Infof("Creating instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v, connectMode %v, labels %v backup source %v",
 		obj.Name,
 		obj.Location,
 		instance.Tier,
 		instance.FileShares[0].CapacityGb,
 		instance.Networks[0].Network,
 		instance.Networks[0].ReservedIpRange,
+		instance.Networks[0].ConnectMode,
 		instance.Labels,
 		instance.FileShares[0].SourceBackup)
 	op, err := manager.instancesService.Create(locationURI(obj.Project, obj.Location), instance).InstanceId(obj.Name).Context(ctx).Do()
@@ -234,6 +239,7 @@ func cloudInstanceToServiceInstance(instance *filev1beta1.Instance) (*ServiceIns
 			Name:            instance.Networks[0].Network,
 			Ip:              instance.Networks[0].IpAddresses[0],
 			ReservedIpRange: instance.Networks[0].ReservedIpRange,
+			ConnectMode:     instance.Networks[0].ConnectMode,
 		},
 		Labels: instance.Labels,
 		State:  instance.State,
@@ -331,17 +337,20 @@ func (manager *gcfsServiceManager) ResizeInstance(ctx context.Context, obj *Serv
 				Network:         obj.Network.Name,
 				Modes:           []string{"MODE_IPV4"},
 				ReservedIpRange: obj.Network.ReservedIpRange,
+				ConnectMode:     obj.Network.ConnectMode,
 			},
 		},
 	}
 
-	glog.V(4).Infof("Patching instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v",
+	glog.V(4).Infof("Patching instance %v: location %v, tier %v, capacity %v, network %v, ipRange %v, connectMode %v",
 		obj.Name,
 		obj.Location,
 		betaObj.Tier,
 		betaObj.FileShares[0].CapacityGb,
 		betaObj.Networks[0].Network,
-		betaObj.Networks[0].ReservedIpRange)
+		betaObj.Networks[0].ReservedIpRange,
+		betaObj.Networks[0].ConnectMode,
+	)
 	op, err := manager.instancesService.Patch(instanceuri, betaObj).UpdateMask(fileShareUpdateMask).Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("Patch operation failed: %v", err)

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -344,7 +344,8 @@ func TestGenerateNewFileInstance(t *testing.T) {
 				Location: testLocation,
 				Tier:     defaultTier,
 				Network: file.Network{
-					Name: defaultNetwork,
+					Name:        defaultNetwork,
+					ConnectMode: directPeering,
 				},
 				Volume: file.Volume{
 					Name:      newInstanceVolume,
@@ -382,7 +383,8 @@ func TestGenerateNewFileInstance(t *testing.T) {
 				Location: "foo-location",
 				Tier:     "foo-tier",
 				Network: file.Network{
-					Name: "foo-network",
+					Name:        "foo-network",
+					ConnectMode: directPeering,
 				},
 				Volume: file.Volume{
 					Name:      newInstanceVolume,
@@ -425,7 +427,8 @@ func TestGenerateNewFileInstance(t *testing.T) {
 				Location: "bar-location",
 				Tier:     "foo-tier",
 				Network: file.Network{
-					Name: "foo-network",
+					Name:        "foo-network",
+					ConnectMode: directPeering,
 				},
 				Volume: file.Volume{
 					Name:      newInstanceVolume,
@@ -456,7 +459,48 @@ func TestGenerateNewFileInstance(t *testing.T) {
 				Location: "foo-location",
 				Tier:     "foo-tier",
 				Network: file.Network{
-					Name: "foo-network",
+					Name:        "foo-network",
+					ConnectMode: directPeering,
+				},
+				Volume: file.Volume{
+					Name:      newInstanceVolume,
+					SizeBytes: testBytes,
+				},
+			},
+		},
+		{
+			name: "custom params, private connect mode",
+			toporeq: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							TopologyKeyZone: "foo-location",
+						},
+					},
+				},
+			},
+			params: map[string]string{
+				paramTier:                       "foo-tier",
+				paramNetwork:                    "foo-network",
+				paramConnectMode:                privateServiceAccess,
+				"csiProvisionerSecretName":      "foo-secret",
+				"csiProvisionerSecretNamespace": "foo-namespace",
+			},
+			instance: &file.ServiceInstance{
+				Project:  testProject,
+				Name:     testCSIVolume,
+				Location: "foo-location",
+				Tier:     "foo-tier",
+				Network: file.Network{
+					Name:        "foo-network",
+					ConnectMode: privateServiceAccess,
 				},
 				Volume: file.Volume{
 					Name:      newInstanceVolume,
@@ -468,6 +512,13 @@ func TestGenerateNewFileInstance(t *testing.T) {
 			name: "invalid params",
 			params: map[string]string{
 				"foo-param": "bar",
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid connect mode",
+			params: map[string]string{
+				paramConnectMode: "CONNECT_MODE_UNSPECIFIED",
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
in order to do that, we need to pass appropriate `connect-mode`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
provision Filestore instances with shared-vpc from service project went into public preview and we need to support it in filestore csi driver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
new parameter `connect-mode` needs to be set to `PRIVATE_SERVICE_ACCESS` if provisioning Filestore instances from service projects of shared-vpc. If a specific range needs to be specified, `reserved-ip-range` needs to be used instead of a CIDR range
```
