### PR TITLE
skip new node stage path test

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -446,6 +446,12 @@ func generateGKETestSkip(testParams *testParameters) string {
 		skipString = skipString + "|VolumeSnapshotDataSource"
 	}
 
+	// https://github.com/kubernetes/kubernetes/pull/107065 changes the node staging path and introduces
+	// this new test which filestore breaks on older node versions.
+	if curVer.lessThan(mustParseVersion("1.24.0")) || (nodeVer != nil && nodeVer.lessThan(mustParseVersion("1.24.0"))) {
+		skipString = skipString + "|should.mount.multiple.PV.pointing.to.the.same.storage.on.the.same.node"
+	}
+
 	return skipString
 }
 


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
Necessary for tests running pre-1.24 k8s versions.

```release-note
None
```
/assign @saikat-royc 