### PR TITLE
build driver image using docker buildx instead of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG BUILDPLATFORM
+
 # Build driver go binary
-FROM golang:1.17.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17.2 as builder
+
+ARG STAGINGVERSION
+ARG TARGETPLATFORM
+
 WORKDIR /go/src/sigs.k8s.io/gcp-filestore-csi-driver
 ADD . .
-ARG TAG=latest
-RUN make driver BINDIR=/bin GCP_FS_CSI_STAGING_VERSION=${TAG}
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver BINDIR=/bin GCP_FS_CSI_STAGING_VERSION=${STAGINGVERSION}
 
 # Install nfs packages
 FROM launcher.gcr.io/google/debian10 as deps


### PR DESCRIPTION

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
In order to support multi-arch build for Filestore CSI driver, we need to build the driver image with docker buildx

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
