### PR TITLE
Add support for CMEK

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ volume. Customizable parameters for volume creation include:
 
 | Parameter         | Values                  | Default                                | Description |
 | ---------------   | ----------------------- |-----------                             | ----------- |
-| tier              | "standard"<br>"premium"<br>"enterprise" | "standard"                             | storage performance tier |
+| tier              | "standard"<br>"premium"<br>"enterprise" | "standard"             | storage performance tier |
 | network           | string                  | "default"                              | VPC name<br>When using "PRIVATE_SERVICE_ACCESS" connect-mode, network needs to be the full VPC name |
 | reserved-ipv4-cidr| string		              | ""                                     | CIDR range to allocate Filestore IP Ranges from.<br>The CIDR must be large enough to accommodate multiple Filestore IP Ranges of /29 each, /24 if enterprise tier is used |
 | reserved-ip-range | string		              | ""                                     | IP range to allocate Filestore IP Ranges from.<br>This flag is used instead of "reserved-ipv4-cidr" when "connect-mode" is set to "PRIVATE_SERVICE_ACCESS" and the value must be an [allocated IP address range](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address).<br>The IP range must be large enough to accommodate multiple Filestore IP Ranges of /29 each, /24 if enterprise tier is used |
 | connect-mode      | "DIRECT_PEERING"<br>"PRIVATE_SERVICE_ACCESS" | "DIRECT_PEERING"  | The network connect mode of the Filestore instance.<br>To provision Filestore instance with shared-vpc from service project, PRIVATE_SERVICE_ACCESS mode must be used |
+| instance-encryption-kms-key | string        | ""                                     | Fully qualified resource identifier for the key to use to encrypt new instances. |
 
 For Kubernetes clusters, these parameters are specified in the StorageClass.
 

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -33,6 +33,7 @@ import (
 const (
 	testProject          = "test-project"
 	testLocation         = "us-central1-c"
+	testRegion           = "us-central1"
 	testIP               = "1.1.1.1"
 	testCSIVolume        = "test-csi"
 	testCSIVolume2       = "test-csi-2"
@@ -507,6 +508,38 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					SizeBytes: testBytes,
 				},
 			},
+		},
+		{
+			name: "custom params, customer kms key",
+			params: map[string]string{
+				paramTier:                       enterpriseTier,
+				paramInstanceEncryptionKmsKey:   "foo-key",
+				"csiProvisionerSecretName":      "foo-secret",
+				"csiProvisionerSecretNamespace": "foo-namespace",
+			},
+			instance: &file.ServiceInstance{
+				Project:  testProject,
+				Name:     testCSIVolume,
+				Location: testRegion,
+				Tier:     enterpriseTier,
+				Network: file.Network{
+					Name:        defaultNetwork,
+					ConnectMode: directPeering,
+				},
+				Volume: file.Volume{
+					Name:      newInstanceVolume,
+					SizeBytes: testBytes,
+				},
+				KmsKeyName: "foo-key",
+			},
+		},
+		{
+			name: "non-enterprise tier, customer kms key",
+			params: map[string]string{
+				paramTier:                     "foo-tier",
+				paramInstanceEncryptionKmsKey: "foo-key",
+			},
+			expectErr: true,
 		},
 		{
 			name: "invalid params",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Added CMEK support by creating a new storage class parameter `instance-encryption-kms-key` and populate `KmsKeyName` field of Filestore create request appropriately.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Now Users can use GCP CMEK feature by specifying storage class parameter `instance-encryption-kms-key`
```
