### PR TITLE
add 404 to user error

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -494,17 +494,20 @@ func IsNotFoundErr(err error) bool {
 }
 
 // This function returns true if the error is a googleapi error caused by users, such as
-// Error 429: Quota limit exceeded, Error 403: Permission Denied, and Error 400: Bad Request
+// Error 429: Quota limit exceeded, Error 403: Permission Denied, Error 400: Bad Request,
+// Error 404: Not found.
 func IsUserError(err error) bool {
 	apiErr, ok := err.(*googleapi.Error)
 	if !ok {
 		return false
 	}
-
-	if apiErr.Code == int(code.Code_RESOURCE_EXHAUSTED) || apiErr.Code == int(code.Code_PERMISSION_DENIED) || apiErr.Code == int(code.Code_INVALID_ARGUMENT) {
-		return true
+	userErrors := map[code.Code]bool{
+		code.Code_RESOURCE_EXHAUSTED: true,
+		code.Code_PERMISSION_DENIED:  true,
+		code.Code_INVALID_ARGUMENT:   true,
+		code.Code_NOT_FOUND:          true,
 	}
-	return false
+	return userErrors[code.Code(apiErr.Code)]
 }
 
 // This function returns the backup URI, the region that was picked to be the backup resource location and error.

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -702,7 +702,11 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	backupObj, err := s.config.fileService.CreateBackup(ctx, filer, req.Name, util.GetBackupLocation(req.GetParameters()))
 	if err != nil {
 		glog.Errorf("Create snapshot for volume Id %s failed: %v", volumeID, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		if file.IsUserError(err) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		} else {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 	tp, err := util.ParseTimestamp(backupObj.CreateTime)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR distinguishes the user errors from the other internal errors that are returned by CreateSnapshot. Right now, we are being alerted for CreateSnapshot failures that are triggered by a user error:  

`
GRPC error: rpc error: code = Internal desc = Create Backup operation failed: googleapi: Error 404: The resource "projects/itc-iris-staging/locations/europe-west1-b/instances/instace-name" was not found., notFound
`

 This is a user error  that will now have code InvalidArgument instead of Internal. Internal error codes are counted as failures, but InvalidArgument error codes are counted as successes, so this changes user errors to InvalidArgument code. 

**Does this PR introduce a user-facing change?**:
```release-note
Users will now see the InvalidArgument error code for the 404 googleapi errors caused by invalid arguments. 
```
