### PR TITLE
change instancelabel and convert sc name to lower case

### DIFF
--- a/pkg/webhook/storageclass_test.go
+++ b/pkg/webhook/storageclass_test.go
@@ -126,6 +126,20 @@ func TestMutateStorageClass(t *testing.T) {
 			patch:       fmt.Sprintf(`[{"op":"add", "path":"/parameters/%s","value": "%s"}]`, InstanceStorageClassLabel, storageClassName),
 		},
 		{
+			name: "should fill in instanceStorageClassLabel if not present and convert to lower case",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta:  metav1.ObjectMeta{Name: strings.ToUpper(storageClassName)},
+				Provisioner: FilestoreCSIDriver,
+				Parameters: map[string]string{
+					"multishare": "true",
+					"tier":       TierEnterprise,
+				},
+			},
+			operation:   v1.Create,
+			shouldAdmit: true,
+			patch:       fmt.Sprintf(`[{"op":"add", "path":"/parameters/%s","value": "%s"}]`, InstanceStorageClassLabel, storageClassName),
+		},
+		{
 			name: "should not change instanceStorageClassLabel if already set",
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta:  metav1.ObjectMeta{Name: storageClassName},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
- `instance-storageclass-label` is more aligned with other storageclass parameters
- If the webhook picks storageclass name as default, the mutate webhook should sanitize the name before adding to the storage class params. Else it puts unnecessary restrictions on the storage class names. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
