### PR TITLE
multishare metric emmision

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,12 +56,13 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var meta metadata.Service
+	var mm *metrics.MetricsManager
 	if *runController {
 		if *enableMultishare {
 			klog.Fatalf("provisioning of multishare instances not supported")
 		}
 		if *httpEndpoint != "" && metrics.IsGKEComponentVersionAvailable() {
-			mm := metrics.NewMetricsManager()
+			mm = metrics.NewMetricsManager()
 			mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
 			mm.EmitGKEComponentVersion()
 		}
@@ -93,6 +94,7 @@ func main() {
 		Cloud:            provider,
 		MetadataService:  meta,
 		EnableMultishare: *enableMultishare,
+		Metrics:          mm,
 	}
 
 	gcfsDriver, err := driver.NewGCFSDriver(config)

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -26,6 +26,7 @@ import (
 	mount "k8s.io/mount-utils"
 	cloud "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider"
 	metadataservice "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/metrics"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
 
@@ -39,6 +40,7 @@ type GCFSDriverConfig struct {
 	Cloud            *cloud.Cloud    // Cloud provider
 	MetadataService  metadataservice.Service
 	EnableMultishare bool
+	Metrics          *metrics.MetricsManager
 }
 
 type GCFSDriver struct {
@@ -62,7 +64,7 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 	if config.Version == "" {
 		return nil, fmt.Errorf("driver version missing")
 	}
-	if config.RunController == false && config.RunNode == false {
+	if !config.RunController && !config.RunNode {
 		return nil, fmt.Errorf("must run at least one controller or node service")
 	}
 
@@ -104,6 +106,7 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 			cloud:            config.Cloud,
 			volumeLocks:      util.NewVolumeLocks(),
 			enableMultishare: config.EnableMultishare,
+			metricsManager:   config.Metrics,
 		})
 	}
 

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -32,6 +32,9 @@ import (
 
 const (
 	modeMultishare = "modeMultishare"
+
+	methodCreateVolume = "CreateVolume"
+	methodDeleteVolume = "DeleteVolume"
 )
 
 // MultishareController handles CSI calls for volumes which use Filestore multishare instances.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog"
 )
@@ -26,36 +29,55 @@ const (
 	// envGKEFilestoreCSIVersion is an environment variable set in the Filestore CSI driver controller manifest
 	// with the current version of the GKE component.
 	envGKEFilestoreCSIVersion = "GKE_FILESTORECSI_VERSION"
+
+	subSystem                   = "filestorecsi"
+	operationsLatencyMetricName = "operations_seconds"
+
+	labelStatusCode    = "grpc_status_code"
+	labelMethodName    = "method_name"
+	labelFilestoreMode = "filestore_mode"
 )
 
 var (
+	metricBuckets = []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600}
+
 	// This metric is exposed only from the controller driver component when GKE_FILESTORECSI_VERSION env variable is set.
 	gkeComponentVersion = metrics.NewGaugeVec(&metrics.GaugeOpts{
 		Name: "component_version",
 		Help: "Metric to expose the version of the FILESTORECSI GKE component.",
 	}, []string{"component_version"})
+
+	operationSeconds = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem: subSystem,
+			Name:      operationsLatencyMetricName,
+			Buckets:   metricBuckets,
+		},
+		[]string{labelStatusCode, labelMethodName, labelFilestoreMode},
+	)
 )
 
-type metricsManager struct {
+type MetricsManager struct {
 	registry metrics.KubeRegistry
 }
 
-func NewMetricsManager() metricsManager {
-	mm := metricsManager{
+func NewMetricsManager() *MetricsManager {
+	mm := &MetricsManager{
 		registry: metrics.NewKubeRegistry(),
 	}
+	mm.registry.MustRegister(operationSeconds)
 	return mm
 }
 
-func (mm *metricsManager) GetRegistry() metrics.KubeRegistry {
+func (mm *MetricsManager) GetRegistry() metrics.KubeRegistry {
 	return mm.registry
 }
 
-func (mm *metricsManager) registerComponentVersionMetric() {
+func (mm *MetricsManager) registerComponentVersionMetric() {
 	mm.registry.MustRegister(gkeComponentVersion)
 }
 
-func (mm *metricsManager) recordComponentVersionMetric() error {
+func (mm *MetricsManager) recordComponentVersionMetric() error {
 	v := getEnvVar(envGKEFilestoreCSIVersion)
 	if v == "" {
 		klog.V(2).Info("Skip emitting component version metric")
@@ -67,7 +89,26 @@ func (mm *metricsManager) recordComponentVersionMetric() error {
 	return nil
 }
 
-func (mm *metricsManager) EmitGKEComponentVersion() error {
+func (mm *MetricsManager) RecordOperationMetrics(opErr error, methodName string, filestoreMode string, opDuration time.Duration) {
+	operationSeconds.WithLabelValues(getErrorCode(opErr), methodName, filestoreMode).Observe(opDuration.Seconds())
+}
+
+func getErrorCode(err error) string {
+	if err == nil {
+		return codes.OK.String()
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		// This is not gRPC error. The operation must have failed before gRPC
+		// method was called, otherwise we would get gRPC error.
+		return "unknown-non-grpc"
+	}
+
+	return st.Code().String()
+}
+
+func (mm *MetricsManager) EmitGKEComponentVersion() error {
 	mm.registerComponentVersionMetric()
 	if err := mm.recordComponentVersionMetric(); err != nil {
 		return err
@@ -84,7 +125,7 @@ type Server interface {
 
 // RegisterToServer registers an HTTP handler for this metrics manager to the
 // given server at the specified address/path.
-func (mm *metricsManager) registerToServer(s Server, metricsPath string) {
+func (mm *MetricsManager) registerToServer(s Server, metricsPath string) {
 	s.Handle(metricsPath, metrics.HandlerFor(
 		mm.GetRegistry(),
 		metrics.HandlerOpts{
@@ -92,7 +133,7 @@ func (mm *metricsManager) registerToServer(s Server, metricsPath string) {
 }
 
 // InitializeHttpHandler sets up a server and creates a handler for metrics.
-func (mm *metricsManager) InitializeHttpHandler(address, path string) {
+func (mm *MetricsManager) InitializeHttpHandler(address, path string) {
 	mux := http.NewServeMux()
 	mm.registerToServer(mux, path)
 	go func() {


### PR DESCRIPTION
and call switching for multishare CreateVolume and DeleteVolume

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

To distinguish volumeOps metric for regular filestore and multi-share instances, we need custom metrics for multi-share volumeOps

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
manually tested by adding dummy metric recorder line
`s.config.metricsManager.RecordOperationMetrics(nil, "CreateVolume", modeMultishare, 3*time.Second)`
and resulted in metric output:

```bash
$ curl localhost:22024/metrics

# HELP component_version [ALPHA] Metric to expose the version of the FILESTORECSI GKE component.
# TYPE component_version gauge
component_version{component_version="1.0.0"} 1
# HELP filestorecsi_operations_seconds [ALPHA]
# TYPE filestorecsi_operations_seconds histogram
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="0.1"} 0
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="0.25"} 0
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="0.5"} 0
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="1"} 0
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="2.5"} 0
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="5"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="10"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="15"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="30"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="60"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="120"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="300"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="600"} 8
filestorecsi_operations_seconds_bucket{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume",le="+Inf"} 8
filestorecsi_operations_seconds_sum{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume"} 24
filestorecsi_operations_seconds_count{filestore_mode="modeMultishare",grpc_status_code="OK",method_name="CreateVolume"} 8
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
