### PR TITLE
fix inconsistency in definition of paramMultishareInstanceScLabel

### DIFF
--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -239,7 +239,7 @@ func (m *MultishareController) generateNewMultishareInstance(instanceName string
 		// ignore IPRange flag as it will be handled at the same place as cidr
 		case paramReservedIPV4CIDR, paramReservedIPRange:
 			continue
-		case strings.ToLower(util.ParamMultishareInstanceScLabel):
+		case paramMultishareInstanceScLabel:
 			continue
 		case ParameterKeyLabels, ParameterKeyPVCName, ParameterKeyPVCNamespace, ParameterKeyPVName:
 		case "csiprovisionersecretname", "csiprovisionersecretnamespace":
@@ -320,7 +320,7 @@ func extractInstanceLabels(parameters map[string]string, driverName string) (map
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
-		case strings.ToLower(util.ParamMultishareInstanceScLabel):
+		case paramMultishareInstanceScLabel:
 			err := util.CheckLabelValueRegex(v)
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -305,8 +305,8 @@ func TestExtractInstanceLabels(t *testing.T) {
 			name:   "user labels",
 			driver: testDriverName,
 			params: map[string]string{
-				ParameterKeyLabels:                  "a=b,c=d",
-				util.ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "a=b,c=d",
+				paramMultishareInstanceScLabel: "testsc",
 			},
 			expectedLabel: map[string]string{
 				tagKeyCreatedBy:                        testDrivernameLabelValue,
@@ -353,18 +353,18 @@ func TestExtractShareLabels(t *testing.T) {
 		{
 			name: "user labels ignored",
 			params: map[string]string{
-				ParameterKeyLabels:                  "a=b,c=d",
-				util.ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "a=b,c=d",
+				paramMultishareInstanceScLabel: "testsc",
 			},
 		},
 		{
 			name: "driver labels",
 			params: map[string]string{
-				ParameterKeyLabels:                  "a=b,c=d",
-				util.ParamMultishareInstanceScLabel: "testsc",
-				ParameterKeyPVCName:                 testPVCName,
-				ParameterKeyPVCNamespace:            testPVCNamespace,
-				ParameterKeyPVName:                  testPVName,
+				ParameterKeyLabels:             "a=b,c=d",
+				paramMultishareInstanceScLabel: "testsc",
+				ParameterKeyPVCName:            testPVCName,
+				ParameterKeyPVCNamespace:       testPVCNamespace,
+				ParameterKeyPVName:             testPVName,
 			},
 			expectedLabel: map[string]string{
 				tagKeyCreatedForClaimName:      testPVCName,
@@ -425,9 +425,9 @@ func TestGenerateNewMultishareInstance(t *testing.T) {
 			instanceName: testInstanceName,
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramConnectMode:                    directPeering,
-					ParameterKeyLabels:                  "a=b,c=d",
-					util.ParamMultishareInstanceScLabel: testInstanceScPrefix,
+					paramConnectMode:               directPeering,
+					ParameterKeyLabels:             "a=b,c=d",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			expectedInstance: &file.MultishareInstance{

--- a/pkg/util/multishare_defs.go
+++ b/pkg/util/multishare_defs.go
@@ -28,7 +28,6 @@ const (
 	MinShareSizeBytes                 int64 = 100 * Gb
 	MaxSharesPerInstance                    = 10
 	NewMultishareInstancePrefix             = "fs-"
-	ParamMultishareInstanceScLabel          = "instanceStorageClassLabel"
 	ParamMultishareInstanceScLabelKey       = "storage_gke_io_storage-class-id"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
there are conflicting const of `paramMultishareInstanceScLabel` and `util. ParamMultishareInstanceScLabel` having different values, specifically the latter has incorrect definition

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
