### PR TITLE
[WIP]change to distroless base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,22 @@ build-and-push-webhook-multi-arch: build-webhook-image-and-push-linux-arm64 buil
 	docker manifest create --amend $(WEBHOOK_STAGINGIMAGE):$(STAGINGVERSION) $(WEBHOOK_STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 $(WEBHOOK_STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64
 	docker manifest push -p $(WEBHOOK_STAGINGIMAGE):$(STAGINGVERSION)
 
+# Used by hack/verify-docker-deps.sh, not used for building artifacts
+validate-container-linux-amd64: init-buildx
+	docker buildx build --platform=linux/amd64 \
+		-t validation_linux_amd64 \
+		--target validation-image \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+
+# Used by hack/verify-docker-deps.sh, not used for building artifacts
+validate-container-linux-arm64: init-buildx
+	docker buildx build --platform=linux/arm64 \
+		-t validation_linux_arm64 \
+		--target validation-image \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+
 # Build the docker image for the core CSI driver.
 build-image-and-push: init-buildx
 		{                                                                   \

--- a/hack/print-missing-deps.sh
+++ b/hack/print-missing-deps.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying Docker Executables have appropriate dependencies"
+
+printMissingDep() {
+  if /usr/bin/ldd "$@" | grep "not found"; then
+    echo "!!! Missing deps for $@ !!!"
+    exit 1
+  fi
+}
+
+export -f printMissingDep
+
+/usr/bin/find / -type f -executable -print | /usr/bin/xargs -I {} /bin/bash -c 'printMissingDep "{}"'

--- a/hack/verify-docker-deps.sh
+++ b/hack/verify-docker-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying Docker Image Dependencies"
+
+PKG_ROOT=$(git rev-parse --show-toplevel)
+
+make -C "${PKG_ROOT}" validate-container-linux-amd64 validate-container-linux-arm64


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
We want to change to a distroless image to decrease the amount of security vulnerabilities. 


**Special notes for your reviewer**:
Currently experiencing the problems explained in [this paste](https://paste.googleplex.com/5489382061506560). The distroless image fails to complete the NodeStageVolume step. NodeStageVolume formats and mounts the node to the staging dir (globalmount). This is where it is failing. If NodeStageVolume succeeds, then the next step that would occur is NodePublishVolume which mounts the volume to the pods dir. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
