### PR TITLE
fix error code mappings

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -29,7 +29,6 @@ import (
 	"github.com/golang/glog"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
-	"google.golang.org/genproto/googleapis/rpc/code"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
@@ -212,17 +211,20 @@ func (manager *gcfsServiceManager) CreateInstance(ctx context.Context, obj *Serv
 		betaObj.Labels)
 	op, err := manager.instancesService.Create(locationURI(obj.Project, obj.Location), betaObj).InstanceId(obj.Name).Context(ctx).Do()
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstance operation failed: %v", err)
+		glog.Errorf("CreateInstance operation failed for instance %s: %v", obj.Name, err)
+		return nil, err
 	}
 
 	glog.V(4).Infof("For instance %v, waiting for create instance op %v to complete", obj.Name, op.Name)
 	err = manager.waitForOp(ctx, op)
 	if err != nil {
-		return nil, fmt.Errorf("WaitFor CreateInstance op %s failed: %v", op.Name, err)
+		glog.Errorf("WaitFor CreateInstance op %s failed: %v", op.Name, err)
+		return nil, err
 	}
 	instance, err := manager.GetInstance(ctx, obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instance after creation: %v", err)
+		glog.Errorf("failed to get instance after creation: %v", err)
+		return nil, err
 	}
 	return instance, nil
 }
@@ -263,17 +265,20 @@ func (manager *gcfsServiceManager) CreateInstanceFromBackupSource(ctx context.Co
 		instance.FileShares[0].SourceBackup)
 	op, err := manager.instancesService.Create(locationURI(obj.Project, obj.Location), instance).InstanceId(obj.Name).Context(ctx).Do()
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstance operation failed: %v", err)
+		glog.Errorf("CreateInstance operation failed for instance %v: %v", obj.Name, err)
+		return nil, err
 	}
 
 	glog.V(4).Infof("For instance %v, waiting for create instance op %v to complete", obj.Name, op.Name)
 	err = manager.waitForOp(ctx, op)
 	if err != nil {
-		return nil, fmt.Errorf("WaitFor CreateInstance op %s failed: %v", op.Name, err)
+		glog.Errorf("WaitFor CreateInstance op %s failed: %v", op.Name, err)
+		return nil, err
 	}
 	serviceInstance, err := manager.GetInstance(ctx, obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instance after creation: %v", err)
+		glog.Errorf("failed to get instance after creation: %v", err)
+		return nil, err
 	}
 	return serviceInstance, nil
 }
@@ -474,7 +479,8 @@ func (manager *gcfsServiceManager) CreateBackup(ctx context.Context, obj *Servic
 	glog.V(4).Infof("Creating backup object %+v for the URI %v", *backupobj, backupUri)
 	opbackup, err := manager.backupService.Create(locationURI(obj.Project, region), backupobj).BackupId(backupName).Context(ctx).Do()
 	if err != nil {
-		return nil, fmt.Errorf("Create Backup operation failed: %v", err)
+		glog.Errorf("Create Backup operation failed: %v", err)
+		return nil, err
 	}
 
 	glog.V(4).Infof("For backup uri %s, waiting for backup op %v to complete", backupUri, opbackup.Name)
@@ -583,21 +589,26 @@ func IsNotFoundErr(err error) bool {
 	return false
 }
 
-// This function returns true if the error is a googleapi error caused by users, such as
-// Error 429: Quota limit exceeded, Error 403: Permission Denied, Error 400: Bad Request,
-// Error 404: Not found.
+// IsUserError returns true if the error is a googleapi.Error with
+// Error 403: Permission Denied, Error 400: Bad Request
 func IsUserError(err error) bool {
-	apiErr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
+	userErrors := map[int]bool{
+		http.StatusForbidden:  true,
+		http.StatusBadRequest: true,
 	}
-	userErrors := map[code.Code]bool{
-		code.Code_RESOURCE_EXHAUSTED: true,
-		code.Code_PERMISSION_DENIED:  true,
-		code.Code_INVALID_ARGUMENT:   true,
-		code.Code_NOT_FOUND:          true,
+	if apiErr, ok := err.(*googleapi.Error); ok && userErrors[apiErr.Code] {
+		return true
 	}
-	return userErrors[code.Code(apiErr.Code)]
+	return false
+}
+
+// IsTooManyRequestError returns true if the error is a googleapi.Error with
+// Error 429: Status Too Many Requests.
+func IsTooManyRequestError(err error) bool {
+	if apierr, ok := err.(*googleapi.Error); ok && apierr.Code == http.StatusTooManyRequests {
+		return true
+	}
+	return false
 }
 
 // This function returns the backup URI, the region that was picked to be the backup resource location and error.

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -173,8 +173,13 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 
 	// Check if the instance already exists
 	filer, err := s.config.fileService.GetInstance(ctx, newFiler)
-	if err != nil && !file.IsNotFoundErr(err) {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err != nil {
+		if file.IsUserError(err) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		if !file.IsNotFoundErr(err) {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	if filer != nil {
@@ -235,6 +240,8 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			glog.Errorf("Create volume for volume Id %s failed: %v", volumeID, createErr)
 			if file.IsUserError(createErr) {
 				return nil, status.Error(codes.InvalidArgument, createErr.Error())
+			} else if file.IsTooManyRequestError(createErr) {
+				return nil, status.Error(codes.ResourceExhausted, createErr.Error())
 			} else {
 				return nil, status.Error(codes.Internal, createErr.Error())
 			}
@@ -736,7 +743,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	backupObj, err := s.config.fileService.CreateBackup(ctx, filer, req.Name, util.GetBackupLocation(req.GetParameters()))
 	if err != nil {
 		glog.Errorf("Create snapshot for volume Id %s failed: %v", volumeID, err)
-		if file.IsUserError(err) {
+		if file.IsNotFoundErr(err) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		} else {
 			return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
**What type of PR is this?**
Follow up to #206 which had an invalid http mapping. It checked that the grpc code was in the map, not that the http error code is in the map (which is what the googleapi error has in code.  Also had to remove the error wrapping from the CreateInstance and CreateInstanceFromBackupSource functions so that casting to googleapi error is not nil. 

/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
returns InvalidArgument instead of Internal error code for some common user errors which is visible to users with a kubectl describe command 
```
