### PR TITLE
Implement e2e test for NodeGetVolumeStats

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -439,8 +439,8 @@ func getFSStat(path string) (available, capacity, used, inodesFree, inodes, inod
 		return
 	}
 
-	// Available is blocks available * fragment size
-	available = int64(statfs.Bavail) * int64(statfs.Bsize)
+	// Available is blocks available * fragment size to root user
+	available = int64(statfs.Bfree) * int64(statfs.Bsize)
 	// Capacity is total block count * fragment size
 	capacity = int64(statfs.Blocks) * int64(statfs.Bsize)
 	// Usage is block being used * fragment size (aka block size).

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	Gb = 1024 * 1024 * 1024
+	Mb = 1024 * 1024
+	Gb = 1024 * Mb
 	Tb = 1024 * Gb
 
 	// VolumeSnapshot parameters
@@ -60,6 +61,10 @@ func BytesToGb(bytes int64) int64 {
 
 func GbToBytes(gbs int64) int64 {
 	return gbs * Gb
+}
+
+func MbToBytes(mbs int64) int64 {
+	return mbs * Mb
 }
 
 func Min(a, b int64) int64 {

--- a/test/e2e/tests/resize_e2e_test.go
+++ b/test/e2e/tests/resize_e2e_test.go
@@ -16,8 +16,10 @@ package tests
 
 import (
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"strings"
+	"time"
 
 	filev1beta1 "google.golang.org/api/file/v1beta1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -39,6 +41,7 @@ const (
 	defaultTier          = "STANDARD"
 	defaultNetwork       = "default"
 	minVolumeSize  int64 = 1 * util.Tb
+	defaultEpsilon int64 = 70 * util.Gb // when a 1T instance was created, the actual size is 1007G, and only 956G is available to non-root users, so there will be ~70 Gb of space unavailable
 )
 
 var _ = Describe("Google Cloud Filestore CSI Driver", func() {
@@ -51,7 +54,7 @@ var _ = Describe("Google Cloud Filestore CSI Driver", func() {
 
 		validateDisk(diskInfo)
 
-		writeAndReadDisk(diskInfo)
+		writeAndReadDisk(diskInfo, testContext)
 
 		offlineResizeDisk(diskInfo)
 
@@ -59,7 +62,7 @@ var _ = Describe("Google Cloud Filestore CSI Driver", func() {
 	})
 })
 
-func writeAndReadDisk(di *DiskInfo) {
+func writeAndReadDisk(di *DiskInfo, tc *remote.TestContext) {
 	var err error
 	instance := di.TestCtx.Instance
 	volName := di.Name
@@ -97,6 +100,8 @@ func writeAndReadDisk(di *DiskInfo) {
 	}()
 
 	validateRead(secondPublishDir, testFileName, "test", instance)
+
+	validateVolumeStats(publishDir, di.Volume.VolumeId, instance, tc)
 }
 
 func onlineResizeDisk(di *DiskInfo) {
@@ -288,6 +293,23 @@ func validateRead(publishDir, testFileName, testFileContents string, instance *r
 	Expect(strings.TrimSpace(string(readContents))).To(Equal(testFileContents))
 }
 
+func validateVolumeStats(publishDir, volID string, instance *remote.InstanceInfo, tc *remote.TestContext) {
+	// generate a random file between 1 Mb to 100 Mb for usage verification
+	rand.Seed(time.Now().UnixNano())
+	fileSize := 1 + rand.Int63n(100)
+	err := testutils.GenerateRandomFile(instance, publishDir, fileSize)
+	Expect(err).To(BeNil(), "Failed to generate file")
+
+	available, capacity, used, inodesFree, inodes, inodesUsed, err := tc.Client.NodeGetVolumeStats(volID, publishDir)
+	Expect(err).To(BeNil(), "Failed to get node volume stats: %v", err)
+	Expect(equalWithinEpsilon(available, minVolumeSize, defaultEpsilon)).To(BeTrue())
+	Expect(equalWithinEpsilon(capacity, minVolumeSize, defaultEpsilon)).To(BeTrue())
+	Expect(used).To(Equal(util.MbToBytes(fileSize)))
+	Expect(inodesFree == 0).To(BeFalse())
+	Expect(inodes == 0).To(BeFalse())
+	Expect(inodesUsed == 0).To(BeFalse())
+}
+
 func validateDisk(di *DiskInfo) {
 	inst, err := getDisk(di)
 	Expect(err).To(BeNil(), "Could not get disk from cloud directly")
@@ -305,4 +327,11 @@ func validateDisk(di *DiskInfo) {
 			Expect(instV).To(Equal(v), "Expected custom label value does not match expected value")
 		}
 	}
+}
+
+func equalWithinEpsilon(a, b, epsiolon int64) bool {
+	if a > b {
+		return a-b < epsiolon
+	}
+	return b-a < epsiolon
 }

--- a/test/e2e/tests/resize_e2e_test.go
+++ b/test/e2e/tests/resize_e2e_test.go
@@ -41,7 +41,7 @@ const (
 	defaultTier          = "STANDARD"
 	defaultNetwork       = "default"
 	minVolumeSize  int64 = 1 * util.Tb
-	defaultEpsilon int64 = 70 * util.Gb // when a 1T instance was created, the actual size is 1007G, and only 956G is available to non-root users, so there will be ~70 Gb of space unavailable
+	defaultEpsilon int64 = 20 * util.Gb // when a 1T instance was created, the actual size is 1007G, so there will be ~20 Gb of space unavailable
 )
 
 var _ = Describe("Google Cloud Filestore CSI Driver", func() {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -141,6 +141,15 @@ func WriteFile(instance *remote.InstanceInfo, filePath, fileContents string) err
 	return nil
 }
 
+// generate a random file with given size in MiB
+func GenerateRandomFile(instance *remote.InstanceInfo, filePath string, size int64) error {
+	output, err := instance.SSHNoSudo("dd", "if=/dev/urandom", fmt.Sprintf("of=%s/file", filePath), "bs=1MiB", fmt.Sprintf("count=%d", size))
+	if err != nil {
+		return fmt.Errorf("failed to write test file %s. Output: %v, errror: %v", filePath, output, err)
+	}
+	return nil
+}
+
 func ReadFile(instance *remote.InstanceInfo, filePath string) (string, error) {
 	output, err := instance.SSHNoSudo("cat", filePath)
 	if err != nil {

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -206,6 +206,36 @@ func (c *CsiClient) ControllerExpandVolumeWithLimit(volumeID string, sizeBytes, 
 	return err
 }
 
+func (c *CsiClient) NodeGetVolumeStats(volumeID, volumePath string) (available, capacity, used, inodesFree, inodes, inodesUsed int64, err error) {
+	resp, err := c.nodeClient.NodeGetVolumeStats(context.Background(), &csipb.NodeGetVolumeStatsRequest{
+		VolumeId:   volumeID,
+		VolumePath: volumePath,
+	})
+	if err != nil {
+		return
+	}
+	for _, usage := range resp.Usage {
+		if usage == nil {
+			continue
+		}
+		unit := usage.GetUnit()
+		switch unit {
+		case csipb.VolumeUsage_BYTES:
+			available = usage.GetAvailable()
+			capacity = usage.GetTotal()
+			used = usage.GetUsed()
+		case csipb.VolumeUsage_INODES:
+			inodesFree = usage.GetAvailable()
+			inodes = usage.GetTotal()
+			inodesUsed = usage.GetUsed()
+		default:
+			err = fmt.Errorf("unknown key %s in usage", unit.String())
+			return
+		}
+	}
+	return
+}
+
 func (c *CsiClient) CreateSnapshot(snapshotName, sourceVolumeId string) (string, error) {
 	csr := &csipb.CreateSnapshotRequest{
 		Name:           snapshotName,

--- a/test/remote/setup-teardown.go
+++ b/test/remote/setup-teardown.go
@@ -72,7 +72,7 @@ func SetupInstance(instanceProject, instanceZone, instanceName, instanceServiceA
 }
 
 // SetupNewDriverAndClient gets the driver binary, runs it on the provided instance and connects
-// a CSI client to it through SHH tunnelling. It returns a TestContext with both a handle to the instance
+// a CSI client to it through SSH tunnelling. It returns a TestContext with both a handle to the instance
 // that the driver is on and the CSI Client object to make CSI calls to the remote driver.
 func SetupNewDriverAndClient(instance *InstanceInfo, config *ClientConfig) (*TestContext, error) {
 	archivePath, err := CreateDriverArchive(archiveName, config.PkgPath, config.BinPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add test for NodeGetVolumeStats in resize e2e test.
```
