### PR TITLE
register process start time metric for core filestore driver container

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -65,6 +65,7 @@ func NewMetricsManager() *MetricsManager {
 	mm := &MetricsManager{
 		registry: metrics.NewKubeRegistry(),
 	}
+	metrics.RegisterProcessStartTime(mm.registry.Register)
 	mm.registry.MustRegister(operationSeconds)
 	return mm
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"testing"
+)
+
+const (
+	ProcessStartTimeMetric = "process_start_time_seconds"
+)
+
+func TestProcessStartTimeMetricExist(t *testing.T) {
+	mm := NewMetricsManager()
+	metricsFamilies, err := mm.GetRegistry().Gather()
+	if err != nil {
+		t.Fatalf("Error fetching metrics: %v", err)
+	}
+
+	// check 'process_start_time_seconds' metric exist
+	for _, metricsFamily := range metricsFamilies {
+		if metricsFamily.GetName() == ProcessStartTimeMetric {
+			return
+		}
+	}
+
+	t.Fatalf("Metrics does not contain %v. Scraped content: %v", ProcessStartTimeMetric, metricsFamilies)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Filestore CSI driver emits multishare operations latency histogram [metric](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/v1.2.7/pkg/metrics/metrics.go#L50) (which is cummulative). For the metric to work properly, the process start time metric needs to be registered correctly. The csi sidecars do a similar thing for the csi_sidecar_operation_seconds metric. See conversation in b/168620097#comment32. The snippet is 

```
Every application starts growing all cumulative metrics from 0. When application crashes, counter resets. That is true for prometheus metrics. For correctly handling such situations Monarch expects to get information about start time of an application (point of time when counter was reset). If not provided prometheus-to-sd will leave this field empty which means reset time will be equal to 1970. In such case cumulative metrics will be processed incorrectly.
```

Additional note:
Related [PR](https://github.com/kubernetes/kubernetes/pull/98391) to fix the RegisterProcessStartTime which is used by [csi-lib-utils](https://github.com/kubernetes-csi/csi-lib-utils/blob/master/metrics/metrics.go#L224), the same lib used by sidecars. The filestorecsi is already using [0.24.1](https://github.com/kubernetes/component-base/blob/v0.24.1/metrics/processstarttime.go#L37) of k8s.io/component-base ([go.mod](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/v1.2.7/go.mod#L33)), so only a single call to RegisterProcessStartTime() is sufficient, as it should successfully register metric and also record the start time.

Also verified it manually, that the controller emits the process_start_time metric
```
saikatroyc@gke-cluster-5-default-pool-839e3bc1-sz75 ~ $ curl localhost:22024/metrics
# HELP process_start_time_seconds [ALPHA] Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.65648302501e+09
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
register process start time metric for core filestore driver container
```
