### PR TITLE
Choose an older Kubetest2 commit version instead of using latest and manually set timeout to 24h

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -529,6 +529,10 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--skip-regex=%s", skip))
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--parallel=%d", testParams.parallel))
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--test-args=%s", testConfigArg))
+	// Default timeout has been reduced from 24 hours to 1 hours
+	// in k/k repo because Ginkgo v1 is deprecated
+	// since https://github.com/kubernetes/kubernetes/pull/109111.
+	kubeTest2Args = append(kubeTest2Args, "--ginkgo-args=--timeout=24h")
 
 	err = runCommand("Running Tests", exec.Command("kubetest2", kubeTest2Args...))
 	if err != nil {

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -31,10 +31,13 @@ readonly parallel_run=${PARALLEL:-}
 
 make -C "${PKGDIR}" test-k8s-integration
 
-go install sigs.k8s.io/kubetest2@latest;
-go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-go install sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+# Choose an older Kubetest2 commit version instead of using @latest 
+# because of a regression in https://github.com/kubernetes-sigs/kubetest2/pull/183.
+# Contact engprod oncall and ask about what is the version they are using for internal jobs.
+go install sigs.k8s.io/kubetest2@0e09086b60c122e1084edd2368d3d27fe36f384f;
+go install sigs.k8s.io/kubetest2/kubetest2-gce@0e09086b60c122e1084edd2368d3d27fe36f384f;
+go install sigs.k8s.io/kubetest2/kubetest2-gke@0e09086b60c122e1084edd2368d3d27fe36f384f;
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@0e09086b60c122e1084edd2368d3d27fe36f384f;
 
 echo "make successful"
 base_cmd="${PKGDIR}/bin/k8s-integration-test \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
A kubetest2 regression was introduced in https://github.com/kubernetes-sigs/kubetest2/pull/183, it causes our integration tests to fail in both PD and Filestore CSI side. A temp fix is to choose an older Kubetest2 commit version `0e09086b60c122e1084edd2368d3d27fe36f384f` over `@latest`.
Besides, we explicitly set the integration test timeout to 24h. According to https://github.com/kubernetes/kubernetes/pull/109111, timeout has been reduced from 24 hours to 1 hours in k/k repo because Ginkgo v1 is deprecated. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [b/237583494](b/237583494)

**Special notes for your reviewer**:
This is a temp solution to unblock filestore csi 1.2.8 release.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
