### PR TITLE
do not count user errors 404 instance not found and 429 Resource exhausted against SLO

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/glog"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
@@ -608,26 +609,30 @@ func IsNotFoundErr(err error) bool {
 	return false
 }
 
-// IsUserError returns true if the error is a googleapi.Error with
-// Error 403: Permission Denied, Error 400: Bad Request
-func IsUserError(err error) bool {
-	userErrors := map[int]bool{
-		http.StatusForbidden:  true,
-		http.StatusBadRequest: true,
+// IsUserError returns a pointer to the grpc error code that maps to the http
+// error code for the passed in user googleapi error. Returns nil if the
+// given error is not a googleapi error caused by the user. The following
+// http error codes are considered user errors:
+// (1) http 400 Bad Request, returns grpc InvalidArgument,
+// (2) http 403 Forbidden, returns grpc PermissionDenied,
+// (3) http 404 Not Found, returns grpc NotFound
+// (4) http 429 Too Many Requests, returns grpc ResourceExhausted
+func IsUserError(err error) *codes.Code {
+	apiErr, ok := err.(*googleapi.Error)
+	if !ok {
+		return nil
 	}
-	if apiErr, ok := err.(*googleapi.Error); ok && userErrors[apiErr.Code] {
-		return true
-	}
-	return false
-}
 
-// IsTooManyRequestError returns true if the error is a googleapi.Error with
-// Error 429: Status Too Many Requests.
-func IsTooManyRequestError(err error) bool {
-	if apierr, ok := err.(*googleapi.Error); ok && apierr.Code == http.StatusTooManyRequests {
-		return true
+	userErrors := map[int]codes.Code{
+		http.StatusForbidden:       codes.PermissionDenied,
+		http.StatusBadRequest:      codes.InvalidArgument,
+		http.StatusTooManyRequests: codes.ResourceExhausted,
+		http.StatusNotFound:        codes.NotFound,
 	}
-	return false
+	if code, ok := userErrors[apiErr.Code]; ok {
+		return &code
+	}
+	return nil
 }
 
 // This function returns the backup URI, the region that was picked to be the backup resource location and error.


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
We saw 2 unhappy clusters with the error 
```
GRPC error: rpc error: code = Internal desc = Create Backup operation failed: googleapi: Error 429: Quota limit 'BackupsPerRegion' has been exceeded. Limit: 208 in region us-east1.
Create snapshot for volume Id modeInstance/us-east1-b/vol-name/vol1 failed: Create Backup operation failed: googleapi: Error 429: Quota limit 'BackupsPerRegion' has been exceeded. Limit: 208 in region us-east1.
```

We will be adding filtering by error code soon to help with ErrorBudgetUsedTooQuickly alerts, so we should return a  ResourceExausted error code for snapshots as well. 


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
