### PR TITLE
include REPAIRING as valid non-ready state

### DIFF
--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -327,7 +327,7 @@ func (m *MultishareOpsManager) runEligibleInstanceCheck(ctx context.Context, ins
 	nonReadyInstanceCount := 0
 
 	for _, instance := range instances {
-		if instance.State == "CREATING" {
+		if instance.State == "CREATING" || instance.State == "REPAIRING" {
 			klog.Infof("Instance %s/%s/%s with state %s is not ready", instance.Project, instance.Location, instance.Name, instance.State)
 			nonReadyInstanceCount += 1
 			continue

--- a/pkg/csi_driver/multishare_ops_manager_test.go
+++ b/pkg/csi_driver/multishare_ops_manager_test.go
@@ -1575,6 +1575,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					},
 					State: "READY",
 				},
+				{
+					Name:     "instance-5",
+					Location: "us-central1",
+					Project:  "test-project",
+					Labels: map[string]string{
+						util.ParamMultishareInstanceScLabelKey: "testprefix",
+					},
+					State: "ERROR",
+				},
+				{
+					Name:     "instance-6",
+					Location: "us-central1",
+					Project:  "test-project",
+					Labels: map[string]string{
+						util.ParamMultishareInstanceScLabelKey: "testprefix",
+					},
+					State: "SUSPENDED",
+				},
 			},
 			expectedReadyInstance: []*file.MultishareInstance{
 				{
@@ -1587,7 +1605,7 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					State: "READY",
 				},
 			},
-			expectedNonReadyCount: 2,
+			expectedNonReadyCount: 3,
 			ops: []*OpInfo{
 				{
 					Id:     "op1",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Filestore instances can get into `REPAIRING` state and per Filestore team's recommendation we should block on it and wait for the state to go back to `READY`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
[b/239199315](http://b/239199315)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
