### PR TITLE
Instance validation improvement when choosing eligible instances

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -295,17 +295,14 @@ func (manager *fakeServiceManager) ListMultishareInstances(ctx context.Context, 
 func (manager *fakeServiceManager) StartCreateMultishareInstanceOp(ctx context.Context, obj *MultishareInstance) (*filev1beta1multishare.Operation, error) {
 	instance := &MultishareInstance{
 		Project:       defaultProject,
-		Location:      defaultRegion,
+		Location:      obj.Location,
 		Name:          obj.Name,
 		Tier:          obj.Tier,
 		CapacityBytes: obj.CapacityBytes,
-		Network: Network{
-			Name:            obj.Network.Name,
-			Ip:              obj.Network.Ip,
-			ReservedIpRange: obj.Network.ReservedIpRange,
-		},
-		Labels: obj.Labels,
-		State:  "READY",
+		Network:       obj.Network,
+		KmsKeyName:    obj.KmsKeyName,
+		Labels:        obj.Labels,
+		State:         "READY",
 	}
 	manager.createdMultishareInstance[obj.Name] = instance
 	meta := &filev1beta1multishare.OperationMetadata{

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -761,9 +761,11 @@ func TestMultishareCreateVolume(t *testing.T) {
 						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					CapacityBytes: 1 * util.Tb,
-					Tier:          "Enterprise",
+					Tier:          "enterprise",
 					Network: file.Network{
-						Ip: testIP,
+						Ip:          testIP,
+						Name:        defaultNetwork,
+						ConnectMode: directPeering,
 					},
 					State: "READY",
 				},
@@ -775,9 +777,11 @@ func TestMultishareCreateVolume(t *testing.T) {
 						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					CapacityBytes: 1 * util.Tb,
-					Tier:          "Enterprise",
+					Tier:          "enterprise",
 					Network: file.Network{
-						Ip: testIP,
+						Ip:          testIP,
+						Name:        defaultNetwork,
+						ConnectMode: directPeering,
 					},
 					State: "READY",
 				},
@@ -796,6 +800,7 @@ func TestMultishareCreateVolume(t *testing.T) {
 				},
 				Parameters: map[string]string{
 					paramMultishareInstanceScLabel: testInstanceScPrefix,
+					paramTier:                      "enterprise",
 				},
 				VolumeCapabilities: []*csi.VolumeCapability{
 					{

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -17,6 +17,9 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
+	"net"
+
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
 	pbSanitizer "github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
@@ -58,4 +61,13 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 		glog.V(5).Infof("GRPC response: %+v", resp)
 	}
 	return resp, err
+}
+
+// IsIpWithinRange checks if an ip address is within the given ip range.
+func IsIpWithinRange(ipAddress, ipRange string) (bool, error) {
+	_, ipnet, err := net.ParseCIDR(ipRange)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse cidr range %s: %v", ipRange, err)
+	}
+	return ipnet.Contains(net.ParseIP(ipAddress)), nil
 }

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -84,7 +84,7 @@ func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 		return fmt.Errorf("Failed to create firewall rule: %v", err)
 	}
 
-	imageURL := "projects/debian-cloud/global/images/family/debian-9"
+	imageURL := "projects/debian-cloud/global/images/family/debian-11"
 	inst := &compute.Instance{
 		Name:        i.name,
 		MachineType: machineType(i.zone, ""),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
kind feature
> /kind flake

**What this PR does / why we need it**:
When selecting eligible instance, we used to match instance only based on sc prefix. Such matching may lead to potential bug because we didn't consider the ip reservation, network, cmek etc. So this fix is to match instances with a more strict criteria including all potential field for a multishare filestore instance. ([design doc](https://docs.google.com/document/d/1t4M_wa4yEQGvtHInjk5ECSuukZ2a6CXhAVU_wgFymOc/edit#heading=h.uiuhxyj6a9zs))
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [b/240149274](b/240149274), [b/238641345](b/238641345)

**Special notes for your reviewer**:
`reserved-ip-range` matching is skipped for now. We might need to enable it latter if transformation from ip range name to CIDR range is feasible.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
