### PR TITLE
cherry pick #339 #341 to release-1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ARG BUILDPLATFORM
 
 # Build driver go binary
-FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -105,7 +105,7 @@ func newControllerServer(config *controllerServerConfig) csi.ControllerServer {
 	config.ipAllocator = util.NewIPAllocator(make(map[string]bool))
 	if config.enableMultishare {
 		config.multiShareController = NewMultishareController(config.driver, config.fileService, config.cloud, config.volumeLocks, config.ecfsDescription)
-		config.multiShareController.controllerServer = cs
+		config.multiShareController.opsManager.controllerServer = cs
 	}
 	return cs
 }

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -42,13 +42,12 @@ const (
 
 // MultishareController handles CSI calls for volumes which use Filestore multishare instances.
 type MultishareController struct {
-	controllerServer *controllerServer
-	driver           *GCFSDriver
-	fileService      file.Service
-	cloud            *cloud.Cloud
-	opsManager       *MultishareOpsManager
-	volumeLocks      *util.VolumeLocks
-	ecfsDescription  string
+	driver          *GCFSDriver
+	fileService     file.Service
+	cloud           *cloud.Cloud
+	opsManager      *MultishareOpsManager
+	volumeLocks     *util.VolumeLocks
+	ecfsDescription string
 }
 
 func NewMultishareController(driver *GCFSDriver, fileService file.Service, cloud *cloud.Cloud, volumeLock *util.VolumeLocks, ecfsDescription string) *MultishareController {
@@ -96,33 +95,6 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 	instance, err := m.generateNewMultishareInstance(util.NewMultishareInstancePrefix+string(uuid.NewUUID()), req)
 	if err != nil {
 		return nil, err
-	}
-
-	param := req.GetParameters()
-	// If we are creating a new instance, we need pick an unused CIDR range from reserved-ipv4-cidr
-	// If the param was not provided, we default reservedIPRange to "" and cloud provider takes care of the allocation
-	if instance.Network.ConnectMode == privateServiceAccess {
-		if reservedIPRange, ok := param[paramReservedIPRange]; ok {
-			instance.Network.ReservedIpRange = reservedIPRange
-		}
-	} else if reservedIPV4CIDR, ok := param[paramReservedIPV4CIDR]; ok {
-		reservedIPRange, err := m.controllerServer.reserveIPRange(ctx, &file.ServiceInstance{
-			Project:  instance.Project,
-			Name:     instance.Name,
-			Location: instance.Location,
-			Tier:     instance.Tier,
-		}, reservedIPV4CIDR)
-
-		// Possible cases are 1) CreateInstanceAborted, 2)CreateInstance running in background
-		// The ListInstances response will contain the reservedIPRange if the operation was started
-		// In case of abort, the CIDR IP is released and available for reservation
-		defer m.controllerServer.config.ipAllocator.ReleaseIPRange(reservedIPRange)
-		if err != nil {
-			return nil, err
-		}
-
-		// Adding the reserved IP range to the instance object
-		instance.Network.ReservedIpRange = reservedIPRange
 	}
 
 	workflow, share, err := m.opsManager.setupEligibleInstanceAndStartWorkflow(ctx, req, instance)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
#339 updates the golang version to fix cves
#341 contains critical fix for ip reservation behavior for multi-share

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Golang Version now at 1.18.4
fixed multishare volume provision failure when using IP reservation
```
