### PR TITLE
Replace invalid characters in label values

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -907,3 +907,42 @@ func TestCreateSnapshot(t *testing.T) {
 		}
 	}
 }
+
+func TestReplaceInvalidChars(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Is valid",
+			input:    "filestore_csi_storage_gke_io66m92",
+			expected: "filestore_csi_storage_gke_io66m92",
+		},
+		{
+			name:     "Input contains multiple invalid characteres",
+			input:    "filestore_csi_storage_gke_io!@#$%^&*()",
+			expected: "filestore_csi_storage_gke_io__________",
+		},
+		{
+			name:     "Input contains multiple dots",
+			input:    "filestore.csi.storage.gke.io66m92",
+			expected: "filestore_csi_storage_gke_io66m92",
+		},
+		{
+			name:     "Input contains multiple dashes",
+			input:    "filestore-csi-storage-gke-io66m92",
+			expected: "filestore-csi-storage-gke-io66m92",
+		},
+	}
+
+	for _, test := range cases {
+		r, err := replaceInvalidChars(test.input)
+		if err != nil {
+			t.Errorf("test %q failed: %v", test.name, err)
+		}
+		if r != test.expected {
+			t.Errorf("test %q failed: expected %q, got %q", test.name, test.expected, r)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:


The backend report multiple errors like this when the CSI Driver is
tested with the External Test Suite:

```
googleapi: Error 400: resource labels are invalid: value "filestore.csi.storage.gke.io66m92" contains invalid character '.' at index 9 for key "kubernetes_io_created-for_pvc_name", badRequest
```

This patch proposes to replace invalid characters, as described here [a], in label values.

[1] https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```
