### PR TITLE
Replace global listInstance call with regional listInstance calls only for allowed regions

### DIFF
--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -467,7 +467,7 @@ func TestGenerateNewMultishareInstance(t *testing.T) {
 				t.Error("expected error, got none")
 			}
 			if !tc.expectErr && err != nil {
-				t.Error("unexpected error")
+				t.Errorf("unexpected error: %q", err)
 			}
 			if !reflect.DeepEqual(filer, tc.expectedInstance) {
 				t.Errorf("got filer %+v, want %+v", filer, tc.expectedInstance)

--- a/pkg/csi_driver/multishare_ops_manager_test.go
+++ b/pkg/csi_driver/multishare_ops_manager_test.go
@@ -30,13 +30,15 @@ import (
 )
 
 const (
-	testInstanceScPrefix = "testinstancescprefix"
+	testInstanceScPrefix = "test-prefix"
 	testInstanceName     = "testInstanceName"
 	testShareName        = "testShareName"
+	testVPCNetwork       = "testSharedNetwork"
 )
 
 var (
 	testInstanceHandle = fmt.Sprintf("%s/%s/%s", testProject, testRegion, testInstanceName)
+	testRegions        = []string{testRegion}
 )
 
 type Item struct {
@@ -471,15 +473,15 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "empty init inistance list",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 		},
@@ -487,34 +489,34 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "non-empty init inistance list",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 			},
 			expectedList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 			},
@@ -523,42 +525,42 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "non-empty init inistance list, 1 instance match",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix-1",
+					paramMultishareInstanceScLabel: testInstanceScPrefix + "1",
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix-1",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix + "1",
 				},
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix-1",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix + "1",
 					},
 				},
 				{
 					Name:     "test-instance-2",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix-2",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix + "2",
 					},
 				},
 			},
 			expectedList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix-1",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix + "1",
 					},
 				},
 			},
@@ -567,58 +569,58 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "non-empty init inistance list, 2 instances match",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 				{
 					Name:     "test-instance-2",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 				{
 					Name:     "test-instance-3",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix-3",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix + "3",
 					},
 				},
 			},
 			expectedList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 				{
 					Name:     "test-instance-2",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 			},
@@ -627,22 +629,22 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "non-specified sc prefix in init instance list",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels:   map[string]string{},
 				},
 			},
@@ -651,16 +653,16 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "1 ip address within, 1 out of reserved-ipv4-cidr",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 					paramReservedIPV4CIDR:          "10.0.0.0/24",
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 				Network: file.Network{
 					ReservedIpRange: "10.0.0.0/24",
@@ -669,10 +671,10 @@ func TestListMatchedInstances(t *testing.T) {
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-0",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/21",
@@ -681,10 +683,10 @@ func TestListMatchedInstances(t *testing.T) {
 				},
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "11.0.0.0/24",
@@ -695,10 +697,10 @@ func TestListMatchedInstances(t *testing.T) {
 			expectedList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-0",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
@@ -711,88 +713,88 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "location, tier, network, connect-mode and cmek alignment test",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 					paramReservedIPV4CIDR:          "10.0.0.0/24",
-					paramTier:                      "enterprise",
-					paramNetwork:                   "shared-network",
+					paramTier:                      enterpriseTier,
+					paramNetwork:                   testVPCNetwork,
 					paramInstanceEncryptionKmsKey:  "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 				Network: file.Network{
 					ReservedIpRange: "10.0.0.0/24",
 					ConnectMode:     directPeering,
-					Name:            "shared-network",
+					Name:            testVPCNetwork,
 				},
-				Tier:       "enterprise",
+				Tier:       enterpriseTier,
 				KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-0",
-					Project:  "test-project",
+					Project:  testProject,
 					Location: "us-west1",
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
-					Tier:       "enterprise",
+					Tier:       enterpriseTier,
 					KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 				{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
-					Tier:       "standard",
+					Tier:       defaultTier,
 					KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 				{
 					Name:     "test-instance-2",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
 						ConnectMode:     directPeering,
-						Name:            "default",
+						Name:            defaultNetwork,
 						Ip:              "10.0.0.2",
 					},
-					Tier:       "enterprise",
+					Tier:       enterpriseTier,
 					KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 				{
 					Name:     "test-instance-3",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
 					Tier:       "enterprise",
@@ -800,51 +802,51 @@ func TestListMatchedInstances(t *testing.T) {
 				},
 				{
 					Name:     "test-instance-4",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/24",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
 					Tier: "enterprise",
 				},
 				{
 					Name:     "test-instance-5",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/21",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
-					Tier:       "enterprise",
+					Tier:       enterpriseTier,
 					KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 			},
 			expectedList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-5",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					Network: file.Network{
 						ReservedIpRange: "10.0.0.0/21",
 						ConnectMode:     directPeering,
-						Name:            "shared-network",
+						Name:            testVPCNetwork,
 						Ip:              "10.0.0.2",
 					},
-					Tier:       "enterprise",
+					Tier:       enterpriseTier,
 					KmsKeyName: "projects/test-project/locations/us-central1/keyRings/test-cmek-key-ring/cryptoKeys/test-cmek-key",
 				},
 			},
@@ -853,25 +855,25 @@ func TestListMatchedInstances(t *testing.T) {
 			name: "invalid reserved-ipv4-cidr",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 					paramReservedIPV4CIDR:          "test-ip-range",
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstanceList: []*file.MultishareInstance{
 				{
 					Name:     "test-instance",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 				},
 			},
@@ -890,7 +892,7 @@ func TestListMatchedInstances(t *testing.T) {
 			}
 
 			manager := NewMultishareOpsManager(cloudProvider)
-			filteredList, err := manager.listMatchedInstances(context.Background(), tc.req, tc.target)
+			filteredList, err := manager.listMatchedInstances(context.Background(), tc.req, tc.target, testRegions)
 			if tc.expectError && err == nil {
 				t.Errorf("expected error: %v", err)
 			}
@@ -899,7 +901,7 @@ func TestListMatchedInstances(t *testing.T) {
 			}
 			for _, fi := range filteredList {
 				if !found(tc.expectedList, fi) {
-					t.Errorf("Failed to find instance")
+					t.Errorf("Failed to find instance %+v", fi)
 				}
 			}
 		})
@@ -918,15 +920,15 @@ func TestContainsOpWithInstanceTargetPrefix(t *testing.T) {
 			name: "empty ops list",
 			inputInstance: &file.MultishareInstance{
 				Name:     "test-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 		},
 		{
 			name: "invalid instance, missing location",
 			inputInstance: &file.MultishareInstance{
 				Name:    "test-instance",
-				Project: "test-project",
+				Project: testProject,
 			},
 			errorExpected: true,
 		},
@@ -934,23 +936,23 @@ func TestContainsOpWithInstanceTargetPrefix(t *testing.T) {
 			name: "invalid instance, missing project",
 			inputInstance: &file.MultishareInstance{
 				Name:     "test-instance",
-				Location: "us-central1",
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
 		{
 			name: "invalid instance, missing name",
 			inputInstance: &file.MultishareInstance{
-				Location: "us-central1",
-				Project:  "test-project",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
 		{
 			name: "valid instance, no running instance prefixed op",
 			inputInstance: &file.MultishareInstance{
-				Location: "us-central1",
-				Project:  "test-project",
+				Project:  testProject,
+				Location: testRegion,
 				Name:     "test-instance",
 			},
 			inputOps: []*OpInfo{
@@ -964,8 +966,8 @@ func TestContainsOpWithInstanceTargetPrefix(t *testing.T) {
 		{
 			name: "valid instance, running instance op",
 			inputInstance: &file.MultishareInstance{
-				Location: "us-central1",
-				Project:  "test-project",
+				Project:  testProject,
+				Location: testRegion,
 				Name:     "test-instance",
 			},
 			inputOps: []*OpInfo{
@@ -980,8 +982,8 @@ func TestContainsOpWithInstanceTargetPrefix(t *testing.T) {
 		{
 			name: "valid instance, running share op",
 			inputInstance: &file.MultishareInstance{
-				Location: "us-central1",
-				Project:  "test-project",
+				Project:  testProject,
+				Location: testRegion,
 				Name:     "test-instance",
 			},
 			inputOps: []*OpInfo{
@@ -1175,7 +1177,7 @@ func TestListMultishareResourceRunningOps(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to fake service: %v", err)
 			}
-			cloudProvider, err := cloud.NewFakeCloud()
+			cloudProvider, _ := cloud.NewFakeCloud()
 			cloudProvider.File = s
 			manager := NewMultishareOpsManager(cloudProvider)
 			ops, err := manager.listMultishareResourceRunningOps(context.Background())
@@ -1208,15 +1210,15 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			},
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-2",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 		},
 		{
 			name: "invalid instance case1",
 			instance: &file.MultishareInstance{
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1224,7 +1226,7 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			name: "invalid instance case2",
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-2",
-				Location: "us-central1",
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1232,7 +1234,7 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			name: "invalid instance case3",
 			instance: &file.MultishareInstance{
 				Name:    "test-instance-2",
-				Project: "test-project",
+				Project: testProject,
 			},
 			errorExpected: true,
 		},
@@ -1240,8 +1242,8 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			name: "error found running op",
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-1",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			ops: []*OpInfo{
 				{
@@ -1255,8 +1257,8 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			name: "no running op match",
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-1",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			ops: []*OpInfo{
 				{
@@ -1272,7 +1274,7 @@ func TestVerifyNoRunningInstanceOps(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to fake service: %v", err)
 			}
-			cloudProvider, err := cloud.NewFakeCloud()
+			cloudProvider, _ := cloud.NewFakeCloud()
 			cloudProvider.File = s
 			manager := NewMultishareOpsManager(cloudProvider)
 			err = manager.verifyNoRunningInstanceOps(tc.instance, tc.ops)
@@ -1307,15 +1309,15 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			},
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-1",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 		},
 		{
 			name: "invalid instance case1",
 			instance: &file.MultishareInstance{
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1323,7 +1325,7 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			name: "invalid instance case2",
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-2",
-				Location: "us-central1",
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1331,7 +1333,7 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			name: "invalid instance case3",
 			instance: &file.MultishareInstance{
 				Name:    "test-instance-2",
-				Project: "test-project",
+				Project: testProject,
 			},
 			errorExpected: true,
 		},
@@ -1345,8 +1347,8 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			},
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-1",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1360,8 +1362,8 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			},
 			instance: &file.MultishareInstance{
 				Name:     "test-instance-1",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 			},
 			errorExpected: true,
 		},
@@ -1372,7 +1374,7 @@ func TestVerifyNoRunningInstanceOrShareOpsForInstance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to fake service: %v", err)
 			}
-			cloudProvider, err := cloud.NewFakeCloud()
+			cloudProvider, _ := cloud.NewFakeCloud()
 			cloudProvider.File = s
 			manager := NewMultishareOpsManager(cloudProvider)
 			err = manager.verifyNoRunningInstanceOrShareOpsForInstance(tc.instance, tc.ops)
@@ -1408,8 +1410,8 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 				},
 				Name: "share-1",
 			},
@@ -1419,7 +1421,7 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
 					Name:     "test-instance-1",
-					Location: "us-central1",
+					Location: testRegion,
 				},
 				Name: "share-1",
 			},
@@ -1430,7 +1432,7 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
 					Name:    "test-instance-1",
-					Project: "test-project",
+					Project: testProject,
 				},
 				Name: "share-1",
 			},
@@ -1440,8 +1442,8 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			name: "invalid share case3",
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 				},
 				Name: "share-1",
 			},
@@ -1452,8 +1454,8 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 				},
 			},
 			errorExpected: true,
@@ -1469,8 +1471,8 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			share: &file.Share{
 				Parent: &file.MultishareInstance{
 					Name:     "test-instance-1",
-					Project:  "test-project",
-					Location: "us-central1",
+					Project:  testProject,
+					Location: testRegion,
 				},
 				Name: "share-1",
 			},
@@ -1483,7 +1485,7 @@ func TestVerifyNoRunningShareOps(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to fake service: %v", err)
 			}
-			cloudProvider, err := cloud.NewFakeCloud()
+			cloudProvider, _ := cloud.NewFakeCloud()
 			cloudProvider.File = s
 			manager := NewMultishareOpsManager(cloudProvider)
 			err = manager.verifyNoRunningShareOps(tc.share, tc.ops)
@@ -1523,33 +1525,33 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "all ready instances",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
 				{
 					Name:     "test-instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1557,19 +1559,19 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			expectedReadyInstance: []*file.MultishareInstance{
 				{
 					Name:     "test-instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
 				{
 					Name:     "test-instance-2",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1579,24 +1581,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances (instance update)",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1614,24 +1616,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances (share create)",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1649,24 +1651,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances (share update)",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1684,24 +1686,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances (share delete)",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1719,24 +1721,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances 0, instance delete not counted as ready",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "DELETING",
 				},
@@ -1753,33 +1755,33 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "non-ready instances (share delete), ready instance",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
 				{
 					Name:     "instance-2",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1787,10 +1789,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			expectedReadyInstance: []*file.MultishareInstance{
 				{
 					Name:     "instance-2",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1808,24 +1810,24 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "no ready instance, no non-ready instance, instance with 10 shares not eligible",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -1835,10 +1837,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-1",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1846,10 +1848,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-2",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1857,10 +1859,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-3",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1868,10 +1870,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-4",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1879,10 +1881,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-5",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1890,10 +1892,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-6",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1901,10 +1903,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-7",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1912,10 +1914,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-8",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1923,10 +1925,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-9",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1934,10 +1936,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 					Name: "share-10",
 					Parent: &file.MultishareInstance{
 						Name:     "instance-1",
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:  testProject,
+						Location: testRegion,
 						Labels: map[string]string{
-							util.ParamMultishareInstanceScLabelKey: "testprefix",
+							util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 						},
 					},
 				},
@@ -1947,69 +1949,69 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "ready instance, non-ready instances, other instance state not count",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "CREATING",
 				},
 				{
 					Name:     "instance-2",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "REPAIRING",
 				},
 				{
 					Name:     "instance-3",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
 				{
 					Name:     "instance-4",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
 				{
 					Name:     "instance-5",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "ERROR",
 				},
 				{
 					Name:     "instance-6",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "SUSPENDED",
 				},
@@ -2017,10 +2019,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			expectedReadyInstance: []*file.MultishareInstance{
 				{
 					Name:     "instance-3",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "READY",
 				},
@@ -2038,33 +2040,33 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			name: "creating instance count as non-ready",
 			req: &csi.CreateVolumeRequest{
 				Parameters: map[string]string{
-					paramMultishareInstanceScLabel: "testprefix",
+					paramMultishareInstanceScLabel: testInstanceScPrefix,
 				},
 			},
 			target: &file.MultishareInstance{
 				Name:     "test-target-instance",
-				Project:  "test-project",
-				Location: "us-central1",
+				Project:  testProject,
+				Location: testRegion,
 				Labels: map[string]string{
-					util.ParamMultishareInstanceScLabelKey: "testprefix",
+					util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 				},
 			},
 			initInstances: []*file.MultishareInstance{
 				{
 					Name:     "instance-1",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "CREATING",
 				},
 				{
 					Name:     "instance-2",
-					Location: "us-central1",
-					Project:  "test-project",
+					Project:  testProject,
+					Location: testRegion,
 					Labels: map[string]string{
-						util.ParamMultishareInstanceScLabelKey: "testprefix",
+						util.ParamMultishareInstanceScLabelKey: testInstanceScPrefix,
 					},
 					State: "ERROR",
 				},
@@ -2085,10 +2087,10 @@ func TestRunEligibleInstanceCheck(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to fake service: %v", err)
 			}
-			cloudProvider, err := cloud.NewFakeCloud()
+			cloudProvider, _ := cloud.NewFakeCloud()
 			cloudProvider.File = s
 			manager := NewMultishareOpsManager(cloudProvider)
-			ready, nonReady, err := manager.runEligibleInstanceCheck(context.Background(), tc.req, tc.ops, tc.target)
+			ready, nonReady, err := manager.runEligibleInstanceCheck(context.Background(), tc.req, tc.ops, tc.target, testRegions)
 			if err != nil {
 				t.Errorf("unexpected error")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
1. ListMultishareInstance call will return a partial result if any of the regions is unreachable. This will result the csi driver in creating redundant instances. After this fix, ListMultishareInstance call will fail earlier if the specified region is unreachable, and retry at the next csi request.
2. Format revision: replace hard coded strings with consts in unit tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #b/243699081

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
