### PR TITLE
filter out instances in different vpc networks

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -35,6 +35,7 @@ const (
 	defaultRegion     = "us-central1"
 	defaultTier       = "BASIC_HDD"
 	defaultCapacityGb = 1024
+	defaultNetwork    = "default"
 )
 
 type fakeServiceManager struct {
@@ -125,6 +126,7 @@ func (manager *fakeServiceManager) ListInstances(ctx context.Context, obj *Servi
 			Tier:     defaultTier,
 			Network: Network{
 				ReservedIpRange: "192.168.92.32/29",
+				Name:            defaultNetwork,
 			},
 			State: "READY",
 		},
@@ -135,6 +137,7 @@ func (manager *fakeServiceManager) ListInstances(ctx context.Context, obj *Servi
 			Tier:     defaultTier,
 			Network: Network{
 				ReservedIpRange: "192.168.92.40/29",
+				Name:            defaultNetwork,
 			},
 			State: "READY",
 		},

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -281,6 +281,9 @@ func (s *controllerServer) getCloudInstancesReservedIPRanges(ctx context.Context
 	if err != nil {
 		return nil, status.Error(codes.Aborted, err.Error())
 	}
+	// Due to unreachable location some instances may not show up here.
+	// TODO: create a new function to take a list of locations
+	// and return error if unreachable contained the region of interest.
 	multiShareInstances, err := s.config.fileService.ListMultishareInstances(ctx, &file.ListFilter{Project: filer.Project, Location: "-"})
 	if err != nil {
 		return nil, status.Error(codes.Aborted, err.Error())

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -286,13 +286,19 @@ func (s *controllerServer) getCloudInstancesReservedIPRanges(ctx context.Context
 		return nil, status.Error(codes.Aborted, err.Error())
 	}
 
-	// Initialize an empty reserved list. It will be populated with all the reservedIPRanges obtained from the cloud instances
+	// Initialize an empty reserved list. It will be populated with all the
+	// reservedIPRanges obtained from the cloud instances in the same VPC network
+	// as the ServiceInstance.
 	cloudInstancesReservedIPRanges := make(map[string]bool)
 	for _, instance := range instances {
-		cloudInstancesReservedIPRanges[instance.Network.ReservedIpRange] = true
+		if strings.EqualFold(instance.Network.Name, filer.Network.Name) {
+			cloudInstancesReservedIPRanges[instance.Network.ReservedIpRange] = true
+		}
 	}
 	for _, instance := range multiShareInstances {
-		cloudInstancesReservedIPRanges[instance.Network.ReservedIpRange] = true
+		if strings.EqualFold(instance.Network.Name, filer.Network.Name) {
+			cloudInstancesReservedIPRanges[instance.Network.ReservedIpRange] = true
+		}
 	}
 	return cloudInstancesReservedIPRanges, nil
 }

--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -149,6 +149,7 @@ func (m *MultishareOpsManager) setupEligibleInstanceAndStartWorkflow(ctx context
 			Name:     instance.Name,
 			Location: instance.Location,
 			Tier:     instance.Tier,
+			Network:  instance.Network,
 		}, reservedIPV4CIDR)
 
 		// Possible cases are 1) CreateInstanceAborted, 2)CreateInstance running in background


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
filter out instances in different vpc networks at ip reservation step
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #b/244645541

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
