### PR TITLE
Silent volume provisioning surprise

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -238,24 +238,28 @@ func TestGetRequestCapacity(t *testing.T) {
 		name          string
 		capRange      *csi.CapacityRange
 		bytes         int64
+		tier	      string
 		errorExpected bool
 	}{
 		{
 			name:  "default",
 			bytes: 1 * util.Tb,
+			tier:          defaultTier,
 		},
 		{
-			name: "required below min",
+			name: "required below min, limit not provided",
 			capRange: &csi.CapacityRange{
 				RequiredBytes: 100 * util.Gb,
 			},
-			bytes: 1 * util.Tb,
+			tier:          defaultTier,
+			errorExpected: true,
 		},
 		{
 			name: "required equals min",
 			capRange: &csi.CapacityRange{
 				RequiredBytes: 1 * util.Tb,
 			},
+			tier:  defaultTier,
 			bytes: 1 * util.Tb,
 		},
 		{
@@ -263,6 +267,7 @@ func TestGetRequestCapacity(t *testing.T) {
 			capRange: &csi.CapacityRange{
 				RequiredBytes: 1*util.Tb + 1*util.Gb,
 			},
+			tier:  defaultTier,
 			bytes: 1*util.Tb + 1*util.Gb,
 		},
 		{
@@ -270,6 +275,7 @@ func TestGetRequestCapacity(t *testing.T) {
 			capRange: &csi.CapacityRange{
 				LimitBytes: 1 * util.Tb,
 			},
+			tier:  defaultTier,
 			bytes: 1 * util.Tb,
 		},
 		{
@@ -277,6 +283,7 @@ func TestGetRequestCapacity(t *testing.T) {
 			capRange: &csi.CapacityRange{
 				LimitBytes: 1*util.Tb + 1*util.Gb,
 			},
+			tier:  defaultTier,
 			bytes: 1*util.Tb + 1*util.Gb,
 		},
 		{
@@ -285,6 +292,7 @@ func TestGetRequestCapacity(t *testing.T) {
 				RequiredBytes: 100 * util.Gb,
 				LimitBytes:    2 * util.Tb,
 			},
+			tier:  defaultTier,
 			bytes: 1 * util.Tb,
 		},
 		{
@@ -293,6 +301,7 @@ func TestGetRequestCapacity(t *testing.T) {
 				RequiredBytes: 100 * util.Gb,
 				LimitBytes:    500 * util.Gb,
 			},
+			tier:          defaultTier,
 			errorExpected: true,
 		},
 		{
@@ -301,20 +310,173 @@ func TestGetRequestCapacity(t *testing.T) {
 				RequiredBytes: 5 * util.Tb,
 				LimitBytes:    2 * util.Tb,
 			},
+			tier:          defaultTier,
 			errorExpected: true,
 		},
 		{
-			name: "limit below min",
+			name: "limit below min default",
 			capRange: &csi.CapacityRange{
 				LimitBytes: 100 * util.Gb,
 			},
+			tier:          defaultTier,
 			errorExpected: true,
 		},
+		{
+			name: "required above max default",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 100 * util.Tb,
+			},
+			tier:          defaultTier,
+			errorExpected: true,
+		},
+		{
+			name: "limit above max and no min provided",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 100 * util.Tb,
+			},
+			tier:          defaultTier,
+			errorExpected: true,
+		},
+		{
+			name: "limit above max but min in range",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 100 * util.Tb,
+				RequiredBytes: 15 * util.Tb,
+			},
+			tier:          defaultTier,
+			bytes: 15 * util.Tb,
+		},
+		{
+			name: "limit below min enterprise",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 100 * util.Gb,
+			},
+			tier:          enterpriseTier,
+			errorExpected: true,
+		},
+		{
+			name: "required above max enterprise",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 100 * util.Tb,
+			},
+			tier:          enterpriseTier,
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range enterprise",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 2 * util.Tb,
+				LimitBytes: 3 * util.Tb,
+			},
+			tier:          enterpriseTier,
+			bytes: 2 * util.Tb,
+		},
+		{
+			name: "limit below min highScale",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 5 * util.Tb,
+			},
+			tier:          highScaleTier,
+			errorExpected: true,
+		},
+		{
+			name: "required above max highScale",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 200 * util.Tb,
+			},
+			tier:          highScaleTier,
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range highScale",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 20 * util.Tb,
+				LimitBytes: 30 * util.Tb,
+			},
+			tier:          highScaleTier,
+			bytes: 20 * util.Tb,
+		},
+		{
+			name: "limit below min premium",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 1 * util.Tb,
+			},
+			tier:          premiumTier,
+			errorExpected: true,
+		},
+		{
+			name: "required above max premium",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 70 * util.Tb,
+			},
+			tier:          premiumTier,
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range premium",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 3 * util.Tb,
+				LimitBytes: 60 * util.Tb,
+			},
+			tier:          premiumTier,
+			bytes: 3 * util.Tb,
+		},
+		{
+			name: "limit below min basicSSD",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 1 * util.Tb,
+			},
+			tier:          basicSSDTier,
+			errorExpected: true,
+		},
+		{
+			name: "required above max basicSSD",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 70 * util.Tb,
+			},
+			tier:          basicSSDTier,
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range basicSSD",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 3 * util.Tb,
+				LimitBytes: 60 * util.Tb,
+			},
+			tier:          basicSSDTier,
+			bytes: 3 * util.Tb,
+		},
+		{
+			name: "limit below min basicHDD",
+			capRange: &csi.CapacityRange{
+				LimitBytes: 100 * util.Gb,
+			},
+			tier:          basicHDDTier,
+			errorExpected: true,
+		},
+		{
+			name: "required above max basicHDD",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 70 * util.Tb,
+			},
+			tier:          basicHDDTier,
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range basicHDD",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 1 * util.Tb,
+				LimitBytes: 60 * util.Tb,
+			},
+			tier:          basicHDDTier,
+			bytes: 1 * util.Tb,
+		},
+
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			bytes, err := getRequestCapacity(tc.capRange)
+			bytes, err := getRequestCapacity(tc.capRange, tc.tier)
 			if err != nil && tc.errorExpected {
 				return
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

Previous Behavior: 
   * if a user requested a volume size smaller than the Standard minimum (1TB), we'd quietly round up to the standard Minimum.
   * we didn't account for different tiers having different minimums
   * we didn't check against the maximum volume size for a tier

New Behavior: 
  * Compare against min/max values of provided tier, instead of always standard. (If tier is unrecognized, default to standard)
  * If the requested min is less than possible min, and no upper bound is given, return an error instead of quietly rounding up
  * vice versa for max
```
