### PR TITLE
Fix error categorization and handling

### DIFF
--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -199,7 +199,7 @@ func (m *MultishareController) DeleteVolume(ctx context.Context, req *csi.Delete
 	if workflow != nil {
 		err = m.waitOnWorkflow(ctx, workflow)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
+			return nil, status.Errorf(codes.Internal, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err.Error())
 		}
 	}
 
@@ -233,7 +233,7 @@ func (m *MultishareController) startAndWaitForInstanceDeleteOrShrink(ctx context
 	}
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		return status.Errorf(codes.Internal, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
+		return status.Errorf(codes.Internal, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err.Error())
 	}
 	return nil
 }
@@ -296,7 +296,7 @@ func (m *MultishareController) ControllerExpandVolume(ctx context.Context, req *
 
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "wait on %s operation %q failed with error: %v", workflow.opType.String(), workflow.opName, err)
+		return nil, status.Errorf(codes.Internal, "wait on %s operation %q failed with error: %v", workflow.opType.String(), workflow.opName, err.Error())
 	}
 	klog.Infof("Wait for operation %s (type %s) completed", workflow.opName, workflow.opType.String())
 
@@ -314,7 +314,7 @@ func (m *MultishareController) ControllerExpandVolume(ctx context.Context, req *
 
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "wait on share expansion op %q failed with error: %v", workflow.opName, err)
+		return nil, status.Errorf(codes.Internal, "wait on share expansion op %q failed with error: %v", workflow.opName, err.Error())
 	}
 
 	return m.getShareAndGenerateCSIControllerExpandVolumeResponse(ctx, share, reqBytes)

--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -331,7 +331,7 @@ func (m *MultishareOpsManager) startShareWorkflow(ctx context.Context, w *Workfl
 func (m *MultishareOpsManager) verifyNoRunningInstanceOrShareOpsForInstance(instance *file.MultishareInstance, ops []*OpInfo) error {
 	instanceUri, err := file.GenerateMultishareInstanceURI(instance)
 	if err != nil {
-		return status.Errorf(codes.Internal, "failed to parse instance handle, err: %v", err)
+		return status.Errorf(codes.Internal, "failed to parse instance handle, err: %v", err.Error())
 	}
 
 	// Check for instance prefix in op target.
@@ -380,7 +380,7 @@ func (m *MultishareOpsManager) runEligibleInstanceCheck(ctx context.Context, req
 		if op == nil {
 			shares, err := m.cloud.File.ListShares(ctx, &file.ListFilter{Project: instance.Project, Location: instance.Location, InstanceName: instance.Name})
 			if err != nil {
-				klog.Errorf("Failed to list shares of instance %s/%s/%s, err:%v", instance.Project, instance.Location, instance.Name, err)
+				klog.Errorf("Failed to list shares of instance %s/%s/%s, err:%v", instance.Project, instance.Location, instance.Name, err.Error())
 				return nil, 0, err
 			}
 			if len(shares) >= util.MaxSharesPerInstance {
@@ -623,7 +623,7 @@ func containsOpWithShareName(shareName string, opType util.OperationType, ops []
 func containsOpWithShareTarget(share *file.Share, opType util.OperationType, ops []*OpInfo) (*OpInfo, error) {
 	shareUri, err := file.GenerateShareURI(share)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to parse share handle, err: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to parse share handle, err: %v", err.Error())
 	}
 
 	for _, op := range ops {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -118,7 +118,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 		if os.IsNotExist(err) {
 			if mkdirErr := os.MkdirAll(targetPath, 0750); mkdirErr != nil {
-				return nil, status.Error(codes.Internal, fmt.Sprintf("mkdir failed on path %s (%v)", targetPath, mkdirErr))
+				return nil, status.Error(codes.Internal, fmt.Sprintf("mkdir failed on path %s (%v)", targetPath, mkdirErr.Error()))
 			}
 		}
 	}
@@ -134,10 +134,10 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	if err != nil {
 		klog.Errorf("Mount %q failed, cleaning up", targetPath)
 		if unmntErr := mount.CleanupMountPoint(stagingTargetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed: %v", targetPath, unmntErr)
+			klog.Errorf("Unmount %q failed: %v", targetPath, unmntErr.Error())
 		}
 
-		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", targetPath, err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", targetPath, err.Error()))
 	}
 
 	klog.V(4).Infof("Successfully mounted %s", targetPath)
@@ -193,12 +193,12 @@ func (s *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVol
 		if os.IsNotExist(err) {
 			return nil, status.Errorf(codes.NotFound, "path %s does not exist", req.VolumePath)
 		}
-		return nil, status.Errorf(codes.Internal, "unknown error when stat on %s: %v", req.VolumePath, err)
+		return nil, status.Errorf(codes.Internal, "unknown error when stat on %s: %v", req.VolumePath, err.Error())
 	}
 
 	available, capacity, used, inodesFree, inodes, inodesUsed, err := getFSStat(req.VolumePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get fs info on path %s: %v", req.VolumePath, err)
+		return nil, status.Errorf(codes.Internal, "failed to get fs info on path %s: %v", req.VolumePath, err.Error())
 	}
 
 	return &csi.NodeGetVolumeStatsResponse{
@@ -236,7 +236,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	}
 
 	if err := validateVolumeCapability(volumeCapability); err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("VolumeCapability is invalid: %v", err))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("VolumeCapability is invalid: %v", err.Error()))
 	}
 
 	// Validate volume attributes
@@ -283,7 +283,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	if needsCreateDir {
 		klog.V(4).Infof("NodeStageVolume attempting mkdir for path %s", stagingTargetPath)
 		if err := os.MkdirAll(stagingTargetPath, 0750); err != nil {
-			return nil, fmt.Errorf("mkdir failed for path %s (%v)", stagingTargetPath, err)
+			return nil, fmt.Errorf("mkdir failed for path %s (%w)", stagingTargetPath, err)
 		}
 	}
 
@@ -299,9 +299,9 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	if err != nil {
 		klog.Errorf("Mount %q failed, cleaning up", stagingTargetPath)
 		if unmntErr := mount.CleanupMountPoint(stagingTargetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed: %v", stagingTargetPath, unmntErr)
+			klog.Errorf("Unmount %q failed: %v", stagingTargetPath, unmntErr.Error())
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", stagingTargetPath, err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", stagingTargetPath, err.Error()))
 	}
 
 	klog.V(4).Infof("NodeStageVolume succeeded on volume %v to path %s", volumeID, stagingTargetPath)
@@ -435,7 +435,7 @@ func getFSStat(path string) (available, capacity, used, inodesFree, inodes, inod
 	statfs := &unix.Statfs_t{}
 	err = unix.Statfs(path, statfs)
 	if err != nil {
-		err = fmt.Errorf("failed to get fs info on path %s: %v", path, err)
+		err = fmt.Errorf("failed to get fs info on path %s: %w", path, err)
 		return
 	}
 

--- a/pkg/csi_driver/server.go
+++ b/pkg/csi_driver/server.go
@@ -92,7 +92,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	klog.Infof("Start listening with scheme %v, addr %v", u.Scheme, addr)
 	listener, err := net.Listen(u.Scheme, addr)
 	if err != nil {
-		klog.Fatalf("Failed to listen: %v", err)
+		klog.Fatalf("Failed to listen: %v", err.Error())
 	}
 
 	opts := []grpc.ServerOption{

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -56,7 +56,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	klog.V(5).Infof("GRPC request: %+v", pbSanitizer.StripSecretsCSI03(req).String())
 	resp, err := handler(ctx, req)
 	if err != nil {
-		klog.Errorf("GRPC error: %v", err)
+		klog.Errorf("GRPC error: %v", err.Error())
 	} else {
 		klog.V(5).Infof("GRPC response: %+v", resp)
 	}
@@ -67,7 +67,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 func IsIpWithinRange(ipAddress, ipRange string) (bool, error) {
 	_, ipnet, err := net.ParseCIDR(ipRange)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse cidr range %s: %v", ipRange, err)
+		return false, fmt.Errorf("failed to parse cidr range %s: %w", ipRange, err)
 	}
 	return ipnet.Contains(net.ParseIP(ipAddress)), nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -140,7 +140,7 @@ func (mm *MetricsManager) InitializeHttpHandler(address, path string) {
 	go func() {
 		klog.Infof("Metric server listening at %q", address)
 		if err := http.ListenAndServe(address, mux); err != nil {
-			klog.Fatalf("Failed to start metric server at specified address (%q) and path (%q): %s", address, path, err)
+			klog.Fatalf("Failed to start metric server at specified address (%q) and path (%q): %s", address, path, err.Error())
 		}
 	}()
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -156,12 +156,12 @@ func GetRegionFromZone(location string) (string, error) {
 func ParseTimestamp(timestamp string) (*timestamppb.Timestamp, error) {
 	t, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to parse timestamp %v: %v", timestamp, err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to parse timestamp %v: %v", timestamp, err.Error()))
 	}
 
 	tp, err := ptypes.TimestampProto(t)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to covert timestamp %v: %v", timestamp, err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to covert timestamp %v: %v", timestamp, err.Error()))
 	}
 	return tp, err
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -180,13 +180,13 @@ func main(cmd *cobra.Command, args []string) {
 	defer cancel() // stops certwatcher
 	cw, err := certwatcher.New(certFile, keyFile)
 	if err != nil {
-		klog.Fatalf("failed to initialize new cert watcher: %v", err)
+		klog.Fatalf("failed to initialize new cert watcher: %v", err.Error())
 	}
 	tlsConfig := &tls.Config{
 		GetCertificate: cw.GetCertificate,
 	}
 
 	if err := startServer(ctx, tlsConfig, cw); err != nil {
-		klog.Fatalf("server stopped: %v", err)
+		klog.Fatalf("server stopped: %v", err.Error())
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix the error wrapping logic so that the correct error code can be unwrapped correctly. The rule here is for fmt.Errorf, use %w and err. For logging, use %v and err.Error with nil check on the error. Similar to pr https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1092

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
