### PR TITLE
Simplify status.Error to status.Errorf to avoid fmt.Sprintf

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -184,7 +184,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			id := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
 			isBackupSource, err := util.IsBackupHandle(id)
 			if err != nil || !isBackupSource {
-				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Unsupported volume content source %v", id))
+				return nil, status.Errorf(codes.InvalidArgument, "Unsupported volume content source %v", id)
 			}
 			_, err = s.config.fileService.GetBackup(ctx, id)
 			if err != nil {
@@ -192,7 +192,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 				if errCode := file.IsUserError(err); errCode != nil {
 					return nil, status.Error(*errCode, err.Error())
 				}
-				return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to get snapshot %v: %v", id, err.Error()))
+				return nil, status.Errorf(codes.Internal, "Failed to get snapshot %v: %v", id, err.Error())
 			}
 			sourceSnapshotId = id
 		}
@@ -232,7 +232,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		if newFiler.Network.ConnectMode == privateServiceAccess {
 			if reservedIPRange, ok := param[paramReservedIPRange]; ok {
 				if IsCIDR(reservedIPRange) {
-					return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("When using connect mode PRIVATE_SERVICE_ACCESS, if reserved IP range is specified, it must be a named address range instead of direct CIDR value %v", reservedIPRange))
+					return nil, status.Errorf(codes.InvalidArgument, "When using connect mode PRIVATE_SERVICE_ACCESS, if reserved IP range is specified, it must be a named address range instead of direct CIDR value %v", reservedIPRange)
 				}
 				newFiler.Network.ReservedIpRange = reservedIPRange
 			}
@@ -410,7 +410,7 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if newFiler == nil {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("volume %v doesn't exist", volumeID))
+		return nil, status.Errorf(codes.NotFound, "volume %v doesn't exist", volumeID)
 	}
 
 	// Validate that the volume matches the capabilities
@@ -681,7 +681,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	}
 
 	if hasPendingOps {
-		return nil, status.Error(codes.DeadlineExceeded, fmt.Sprintf("Update operation ongoing for volume %v", volumeID))
+		return nil, status.Errorf(codes.DeadlineExceeded, "Update operation ongoing for volume %v", volumeID)
 	}
 
 	filer.Volume.SizeBytes = reqBytes
@@ -859,21 +859,21 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	} else {
 		backupSourceCSIHandle, err := util.BackupVolumeSourceToCSIVolumeHandle(backupInfo.SourceVolumeHandle)
 		if err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("Cannot determine volume handle from back source %s", backupInfo.SourceVolumeHandle))
+			return nil, status.Errorf(codes.Internal, "Cannot determine volume handle from back source %s", backupInfo.SourceVolumeHandle)
 		}
 		if backupSourceCSIHandle != volumeID {
-			return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Backup already exists with a different source volume %s, input source volume %s", backupInfo.SourceVolumeHandle, volumeID))
+			return nil, status.Errorf(codes.AlreadyExists, "Backup already exists with a different source volume %s, input source volume %s", backupInfo.SourceVolumeHandle, volumeID)
 		}
 		// Check if backup is in the process of getting created.
 		if backupInfo.Backup.State == "CREATING" || backupInfo.Backup.State == "FINALIZING" {
-			return nil, status.Error(codes.DeadlineExceeded, fmt.Sprintf("Backup %v not yet ready, current state %s", backupInfo.Backup.Name, backupInfo.Backup.State))
+			return nil, status.Errorf(codes.DeadlineExceeded, "Backup %v not yet ready, current state %s", backupInfo.Backup.Name, backupInfo.Backup.State)
 		}
 		if backupInfo.Backup.State != "READY" {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("Backup %v not yet ready, current state %s", backupInfo.Backup.Name, backupInfo.Backup.State))
+			return nil, status.Errorf(codes.Internal, "Backup %v not yet ready, current state %s", backupInfo.Backup.Name, backupInfo.Backup.State)
 		}
 		tp, err := util.ParseTimestamp(backupInfo.Backup.CreateTime)
 		if err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to parse create timestamp for backup %v", backupInfo.Backup.Name))
+			return nil, status.Errorf(codes.Internal, "failed to parse create timestamp for backup %v", backupInfo.Backup.Name)
 		}
 		klog.V(4).Infof("CreateSnapshot success for volume %v, Backup Id: %v", volumeID, backupInfo.Backup.Name)
 		return &csi.CreateSnapshotResponse{
@@ -942,7 +942,7 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 	}
 
 	if backupInfo.Backup.State == "DELETING" {
-		return nil, status.Error(codes.DeadlineExceeded, fmt.Sprintf("Volume snapshot with ID %v is in state %s", id, backupInfo.Backup.State))
+		return nil, status.Errorf(codes.DeadlineExceeded, "Volume snapshot with ID %v is in state %s", id, backupInfo.Backup.State)
 	}
 
 	if err = s.config.fileService.DeleteBackup(ctx, id); err != nil {

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -253,7 +253,7 @@ func (m *MultishareController) ControllerExpandVolume(ctx context.Context, req *
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	if !util.IsAligned(reqBytes, util.Gb) {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("requested size(bytes) %d is not a multiple of 1GiB", reqBytes))
+		return nil, status.Errorf(codes.InvalidArgument, "requested size(bytes) %d is not a multiple of 1GiB", reqBytes)
 	}
 	_, project, location, instanceName, shareName, err := parseMultishareVolId(req.VolumeId)
 	if err != nil {
@@ -376,7 +376,7 @@ func (m *MultishareController) generateNewMultishareInstance(instanceName string
 		case paramConnectMode:
 			connectMode = v
 			if connectMode != directPeering && connectMode != privateServiceAccess {
-				return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("connect mode can only be one of %q or %q", directPeering, privateServiceAccess))
+				return nil, status.Errorf(codes.InvalidArgument, "connect mode can only be one of %q or %q", directPeering, privateServiceAccess)
 			}
 		case paramInstanceEncryptionKmsKey:
 			kmsKeyName = v
@@ -390,12 +390,12 @@ func (m *MultishareController) generateNewMultishareInstance(instanceName string
 		case ParameterKeyLabels, ParameterKeyPVCName, ParameterKeyPVCNamespace, ParameterKeyPVName, paramMultishare:
 		case "csiprovisionersecretname", "csiprovisionersecretnamespace":
 		default:
-			return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("invalid parameter %q", k))
+			return nil, status.Errorf(codes.InvalidArgument, "invalid parameter %q", k)
 		}
 	}
 
 	if tier != enterpriseTier {
-		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("tier %q not supported for multishare volumes", tier))
+		return nil, status.Errorf(codes.InvalidArgument, "tier %q not supported for multishare volumes", tier)
 	}
 
 	location := m.cloud.Zone

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -118,7 +118,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 		if os.IsNotExist(err) {
 			if mkdirErr := os.MkdirAll(targetPath, 0750); mkdirErr != nil {
-				return nil, status.Error(codes.Internal, fmt.Sprintf("mkdir failed on path %s (%v)", targetPath, mkdirErr.Error()))
+				return nil, status.Errorf(codes.Internal, "mkdir failed on path %s (%v)", targetPath, mkdirErr.Error())
 			}
 		}
 	}
@@ -137,7 +137,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			klog.Errorf("Unmount %q failed: %v", targetPath, unmntErr.Error())
 		}
 
-		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", targetPath, err.Error()))
+		return nil, status.Errorf(codes.Internal, "mount %q failed: %v", targetPath, err.Error())
 	}
 
 	klog.V(4).Infof("Successfully mounted %s", targetPath)
@@ -236,7 +236,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	}
 
 	if err := validateVolumeCapability(volumeCapability); err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("VolumeCapability is invalid: %v", err.Error()))
+		return nil, status.Errorf(codes.InvalidArgument, "VolumeCapability is invalid: %v", err.Error())
 	}
 
 	// Validate volume attributes
@@ -301,7 +301,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		if unmntErr := mount.CleanupMountPoint(stagingTargetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
 			klog.Errorf("Unmount %q failed: %v", stagingTargetPath, unmntErr.Error())
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("mount %q failed: %v", stagingTargetPath, err.Error()))
+		return nil, status.Errorf(codes.Internal, "mount %q failed: %v", stagingTargetPath, err.Error())
 	}
 
 	klog.V(4).Infof("NodeStageVolume succeeded on volume %v to path %s", volumeID, stagingTargetPath)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -156,12 +156,12 @@ func GetRegionFromZone(location string) (string, error) {
 func ParseTimestamp(timestamp string) (*timestamppb.Timestamp, error) {
 	t, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to parse timestamp %v: %v", timestamp, err.Error()))
+		return nil, status.Errorf(codes.Internal, "Failed to parse timestamp %v: %v", timestamp, err.Error())
 	}
 
 	tp, err := ptypes.TimestampProto(t)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to covert timestamp %v: %v", timestamp, err.Error()))
+		return nil, status.Errorf(codes.Internal, "Failed to covert timestamp %v: %v", timestamp, err.Error())
 	}
 	return tp, err
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug


/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Simply error handling, similar to https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1092


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
