### PR TITLE
change kubetest2 version because prow is failing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2094,7 +2094,6 @@ k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -31,13 +31,15 @@ readonly parallel_run=${PARALLEL:-}
 
 make -C "${PKGDIR}" test-k8s-integration
 
-# Choose an older Kubetest2 commit version instead of using @latest 
+# Choose an older Kubetest2 commit version instead of using @latest
 # because of a regression in https://github.com/kubernetes-sigs/kubetest2/pull/183.
 # Contact engprod oncall and ask about what is the version they are using for internal jobs.
-go install sigs.k8s.io/kubetest2@0e09086b60c122e1084edd2368d3d27fe36f384f;
-go install sigs.k8s.io/kubetest2/kubetest2-gce@0e09086b60c122e1084edd2368d3d27fe36f384f;
-go install sigs.k8s.io/kubetest2/kubetest2-gke@0e09086b60c122e1084edd2368d3d27fe36f384f;
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@0e09086b60c122e1084edd2368d3d27fe36f384f;
+# Or check https://source.corp.google.com/cloud-gke/test-infra/prow/gob/config_gen/kubetest2_gen.py;l=53
+kt2_version=8e2fcda1cf6d37c050304ff64cd696f108ef77b4
+go install sigs.k8s.io/kubetest2@${kt2_version};
+go install sigs.k8s.io/kubetest2/kubetest2-gce@${kt2_version};
+go install sigs.k8s.io/kubetest2/kubetest2-gke@${kt2_version};
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@${kt2_version};
 
 echo "make successful"
 base_cmd="${PKGDIR}/bin/k8s-integration-test \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test


**What this PR does / why we need it**:
we are seeing "deprecated flag in ginkgo" in our prow tests, suspecting it's because kubetest2 version too old.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
