### PR TITLE
fix in correct error passed to IsUserError

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -267,8 +267,8 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 		if createErr != nil {
 			klog.Errorf("Create volume for volume Id %s failed: %v", volumeID, createErr.Error())
-			if errCode := file.IsUserError(err); errCode != nil {
-				return nil, status.Error(*errCode, err.Error())
+			if errCode := file.IsUserError(createErr); errCode != nil {
+				return nil, status.Error(*errCode, createErr.Error())
 			}
 			return nil, status.Error(codes.Internal, createErr.Error())
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line
> /kind bug

**What this PR does / why we need it**:
This PR fixes the bug where the wrong error is passed to IsUserError caused by [this change](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/324/files#r1096395568). This will cause for us to miss filtering out some user errors from the SLO.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
