### PR TITLE
Update sidecar resizer

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.2.0"
+  newTag: "v1.4.0"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
ReadWriteOncePod is a new access mode that enforces a single pod using a volume on a node. CSI sidecars need to be updated to a version that understands the new access mode. The feature is going beta in k8s 1.27. This pr is to update the sidecar for this feature.

These are the minimum sidecar versions:

* csi-provisioner: v3.0.0
* csi-attacher: v3.3.0
* csi-resizer: v1.3.0

More details on the feature at http://kep.k8s.io/2485 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

* rbac hasn't been updated in [the past 3 years](https://github.com/kubernetes-csi/external-resizer/tree/release-1.3/deploy/kubernetes)

* csi-resizer added ``leader-election-lease-duration``, ``leader-election-renew-deadline`` and ``leader-election-retry-period`` in [1.3.0](https://github.com/kubernetes-csi/external-resizer/blob/master/CHANGELOG/CHANGELOG-1.3.md). Default can be found [here](https://github.com/kubernetes-csi/external-resizer/pull/158/files).

**Does this PR introduce a user-facing change?**:
```release-note

Update sidecar for new access mode ReadWriteOncePod in beta k8s 1.27

```
