### PR TITLE
release-1.4 cut details for v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ dynamically created and mounted by workloads.
 ## Project Status
 Status: GA
 
-Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v1.3.10`
+Latest image: `k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver:v1.4.0`
 
 Also see [known issues](KNOWN_ISSUES.md) and [CHANGELOG](CHANGELOG.md).
 
@@ -52,6 +52,7 @@ The following table captures the compatibility matrix of the core filestore driv
 | v1.3.5 (GA)                             |  yes |  yes  |
 | v1.3.9 (GA)                             |  yes |  yes  |
 | v1.3.10 (GA)                            |  yes |  yes  |
+| v1.4.0 (GA)                             |  yes |  yes  |
 | master                                  |  yes |  yes  |
 
 The manifest bundle which captures all the driver components (driver pod which includes the containers csi-external-provisioner, csi-external-resizer, csi-external-snapshotter, gcp-filestore-driver, csi-driver-registrar, csi driver object, rbacs, pod security policies etc) can be picked up from the master branch [overlays](deploy/kubernetes/overlays) directory. We structure the overlays directory per minor version of kubernetes because not all driver components can be used with all kubernetes versions. For example volume snapshots are supported 1.17+ kubernetes versions thus [stable-1-16](deploy/kubernetes/overlays/stable-1-16) driver manifests does not contain the snapshotter sidecar. Read more about overlays [here](docs/release/overlays.md).

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-resize-prow
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.2.0"
+  newTag: "v1.4.0"
 ---
 
 apiVersion: builtin
@@ -40,5 +40,5 @@ metadata:
   name: imagetag-gce-fs-driver
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newTag: "v1.3.10"
+  newTag: "v1.4.0"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
Update container `gcp-filestore-driver` image to v1.4.0 for stable-master overlays

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Next steps is to cherry pick this PR to release-1.4, create a release tag v1.4.0, and then add the new image to promoter (k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
