### PR TITLE
Update sidecar to match internal versions

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v3.1.0"
+  newTag: "v3.4.0"
 ---
 
 apiVersion: builtin
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.4.0"
+  newTag: "v1.7.0"
 ---
 
 apiVersion: builtin
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-snapshotter-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v4.1.0"
+  newTag: "v6.1.0"
 ---
 
 apiVersion: builtin
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.2.0"
+  newTag: "v2.7.0"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Update sidecar versions to match internal versions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

* csi-provisioner v3.4.0 [1. diff](https://github.com/kubernetes-csi/external-provisioner/compare/v3.2.1...v3.4.0) [2. change log](https://github.com/kubernetes-csi/external-provisioner/tree/master/CHANGELOG)

    Added --enable-pprof option but we are not using it.

* csi-resizer v1.7.0 [1. diff](https://github.com/kubernetes-csi/external-resizer/compare/v1.4.0...v1.7.0) [2. change log](https://github.com/kubernetes-csi/external-resizer/tree/master/CHANGELOG)
* csi-snapshotter v6.1.0 [1. diff](https://github.com/kubernetes-csi/external-snapshotter/compare/v4.1.0...v6.1.0)  [2. change log](https://github.com/kubernetes-csi/external-snapshotter/tree/master/CHANGELOG)
* csi-node-driver-registrar v2.7.0 [1. diff](https://github.com/kubernetes-csi/node-driver-registrar/compare/v2.5.1...v2.7.0) [2. change logs](https://github.com/kubernetes-csi/node-driver-registrar/tree/master/CHANGELOG)

**Does this PR introduce a user-facing change?**:

```release-note
Update sidecar to match internal versions

```
