### PR TITLE
Automated cherry pick of #432: Update sidecar to match internal versions

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v3.1.0"
+  newTag: "v3.4.0"
 ---
 
 apiVersion: builtin
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.2.0"
+  newTag: "v1.7.0"
 ---
 
 apiVersion: builtin
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-snapshotter-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v4.1.0"
+  newTag: "v6.1.0"
 ---
 
 apiVersion: builtin
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.2.0"
+  newTag: "v2.7.0"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
Cherry pick of #432 on release-1.3.

#432: Update sidecar to match internal versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```