### PR TITLE
Fix backup source comparison logic for single share instances

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -164,8 +164,9 @@ func (manager *fakeServiceManager) CreateBackup(ctx context.Context, obj *Servic
 
 	backupSource := fmt.Sprintf("projects/%s/locations/%s/instances/%s", obj.Project, obj.Location, obj.Name)
 	if backupInfo, ok := manager.backups[backupUri]; ok {
-		if backupInfo.SourceVolumeHandle != backupSource {
-			return nil, fmt.Errorf("Mismatch in source volume handle for existing snapshot")
+		if backupInfo.SourceInstance != backupSource && backupInfo.SourceShare != obj.Volume.Name {
+			// TODO: format the right info
+			return nil, fmt.Errorf("Mismatch in source for existing snapshot %v", backupInfo)
 		}
 		return backupInfo.Backup, nil
 	}
@@ -179,8 +180,9 @@ func (manager *fakeServiceManager) CreateBackup(ctx context.Context, obj *Servic
 		CapacityGb:      defaultCapacityGb,
 	}
 	manager.backups[backupUri] = &BackupInfo{
-		Backup:             backupToCreate,
-		SourceVolumeHandle: backupSource,
+		Backup:         backupToCreate,
+		SourceInstance: backupSource,
+		SourceShare:    obj.Volume.Name,
 	}
 	return backupToCreate, nil
 }

--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -108,8 +108,9 @@ type Network struct {
 }
 
 type BackupInfo struct {
-	Backup             *filev1beta1.Backup
-	SourceVolumeHandle string
+	Backup         *filev1beta1.Backup
+	SourceInstance string
+	SourceShare    string
 }
 
 type Service interface {
@@ -506,8 +507,9 @@ func (manager *gcfsServiceManager) GetBackup(ctx context.Context, backupUri stri
 		return nil, err
 	}
 	return &BackupInfo{
-		Backup:             backup,
-		SourceVolumeHandle: backup.SourceInstance,
+		Backup:         backup,
+		SourceInstance: backup.SourceInstance,
+		SourceShare:    backup.SourceFileShare,
 	}, nil
 }
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -862,12 +862,12 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		backupSourceCSIHandle, err := util.BackupVolumeSourceToCSIVolumeHandle(backupInfo.SourceVolumeHandle)
+		backupSourceCSIHandle, err := util.BackupVolumeSourceToCSIVolumeHandle(backupInfo.SourceInstance, backupInfo.SourceShare)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Cannot determine volume handle from back source %s", backupInfo.SourceVolumeHandle)
+			return nil, status.Errorf(codes.Internal, "Cannot determine volume handle from back source instance %s, share %s", backupInfo.SourceInstance, backupInfo.SourceShare)
 		}
 		if backupSourceCSIHandle != volumeID {
-			return nil, status.Errorf(codes.AlreadyExists, "Backup already exists with a different source volume %s, input source volume %s", backupInfo.SourceVolumeHandle, volumeID)
+			return nil, status.Errorf(codes.AlreadyExists, "Backup already exists with a different source volume %s, input source volume %s", backupSourceCSIHandle, volumeID)
 		}
 		// Check if backup is in the process of getting created.
 		if backupInfo.Backup.State == "CREATING" || backupInfo.Backup.State == "FINALIZING" {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -199,12 +199,12 @@ func GetBackupLocation(params map[string]string) string {
 	return location
 }
 
-func BackupVolumeSourceToCSIVolumeHandle(backupVolumeSource string) (string, error) {
-	splitId := strings.Split(backupVolumeSource, "/")
+func BackupVolumeSourceToCSIVolumeHandle(sourceInstance, sourceShare string) (string, error) {
+	splitId := strings.Split(sourceInstance, "/")
 	if len(splitId) != volumeTotalElements {
-		return "", fmt.Errorf("Failed to get id components. Expected 'projects/{project}/location/{zone}/instances/{name}'. Got: %s", backupVolumeSource)
+		return "", fmt.Errorf("Failed to get id components. Expected 'projects/{project}/location/{zone}/instances/{name}'. Got: %s", sourceInstance)
 	}
-	return fmt.Sprintf("modeInstance/%s/%s/vol1", splitId[3], splitId[5]), nil
+	return fmt.Sprintf("modeInstance/%s/%s/%s", splitId[3], splitId[5], sourceShare), nil
 }
 
 // Multishare util functions.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If the user uses static provisioning to create filestore instance with a share name which is != "vol1", and the csi driver hits a code path where the backup already exists (say timeout during creation of backup and retry by the csi-snapshotter sidecar), the csi driver uses a logic to compare source volume id handle with a hard coded "vol1". if the driver gets into this state, the volume snapshot object will never converge to true.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix backup source comparison logic for single share instances
```
