### PR TITLE
setup feature gate for configurable shares per instance

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,13 +46,18 @@ var (
 	ecfsDescription                 = flag.String("ecfs-description", "", "Filestore multishare instance descrption. ecfs-version=<version>,image-project-id=<projectid>")
 	isRegional                      = flag.Bool("is-regional", false, "cluster is regional cluster")
 	gkeClusterName                  = flag.String("gke-cluster-name", "", "Cluster Name of the current GKE cluster driver is running on, required for multishare")
-	featureLockRelease              = flag.Bool("feature-lock-release", false, "if set to true, the node driver will support Filestore lock release.")
+
 	// Feature lock release specific parameters, only take effect when feature-lock-release is set to true.
+	featureLockRelease          = flag.Bool("feature-lock-release", false, "if set to true, the node driver will support Filestore lock release.")
 	leaderElectionLeaseDuration = flag.Duration("leader-election-lease-duration", 15*time.Second, "Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.")
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 	lockReleaseSyncPeriod       = flag.Duration("lock-release-sync-period", 60*time.Second, "Duration, in seconds, the sync period of the lock release controller. Defaults to 60 seconds.")
 
+	// Feature configurable shares per Filestore instance specific parameters.
+	featureMaxSharePerInstance = flag.Bool("feature-max-shares-per-instance", false, "If this feature flag is enabled, allows the user to configure max shares packed per Filestore instance")
+	descOverrideMaxShareCount  = flag.String("desc-override-max-shares-per-instance", "", "If non-empty, the filestore instance description override is used to configure max share count per instance. This flag is ignored if 'feature-max-shares-per-instance' flag is false. Both 'desc-override-max-shares-per-instance' and 'desc-override-min-shares-size-gb' must be provided. 'ecfsDescription' is ignored, if this flag is provided.")
+	descOverrideMinShareSizeGB = flag.String("desc-override-min-shares-size-gb", "", "If non-empty, the filestore instance description override is used to configure min share size. This flag is ignored if 'feature-max-shares-per-instance' flag is false. Both 'desc-override-max-shares-per-instance' and 'desc-override-min-shares-size-gb' must be provided. 'ecfsDescription' is ignored, if this flag is provided.")
 	// This is set at compile time
 	version = "unknown"
 )
@@ -109,6 +114,11 @@ func main() {
 				RetryPeriod:   *leaderElectionRetryPeriod,
 				SyncPeriod:    *lockReleaseSyncPeriod,
 			},
+		},
+		FeatureMaxSharesPerInstance: &driver.FeatureMaxSharesPerInstance{
+			Enabled:                          *featureMaxSharePerInstance,
+			DescOverrideMaxSharesPerInstance: *descOverrideMaxShareCount,
+			DescOverrideMinShareSizeGB:       *descOverrideMinShareSizeGB,
 		},
 	}
 	mounter := mount.New("")

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -78,6 +78,7 @@ const (
 	paramMultishare                = "multishare"
 	paramInstanceEncryptionKmsKey  = "instance-encryption-kms-key"
 	paramMultishareInstanceScLabel = "instance-storageclass-label"
+	paramMaxVolumeSize             = "max-volume-size"
 
 	// Keys for PV and PVC parameters as reported by external-provisioner
 	ParameterKeyPVCName      = "csi.storage.k8s.io/pvc/name"

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -77,7 +77,7 @@ func initBlockingTestController(t *testing.T, operationUnblocker chan chan struc
 		fileService: fileService,
 		cloud:       cloudProvider,
 		volumeLocks: util.NewVolumeLocks(),
-		features:    &GCFSDriverFeatureOptions{&FeatureLockRelease{}},
+		features:    &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{}},
 	})
 }
 

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -66,11 +66,19 @@ type GCFSDriver struct {
 type GCFSDriverFeatureOptions struct {
 	// FeatureLockRelease will enable the NFS lock release feature if sets to true.
 	FeatureLockRelease *FeatureLockRelease
+	// FeatureMaxSharesPerInstance will enable CSI driver to pack configurable number of max shares per Filestore instance (multishare)
+	FeatureMaxSharesPerInstance *FeatureMaxSharesPerInstance
 }
 
 type FeatureLockRelease struct {
 	Enabled bool
 	Config  *lockrelease.LockReleaseControllerConfig
+}
+
+type FeatureMaxSharesPerInstance struct {
+	Enabled                          bool
+	DescOverrideMaxSharesPerInstance string
+	DescOverrideMinShareSizeGB       string
 }
 
 func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {

--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -50,14 +50,16 @@ type Workflow struct {
 
 // MultishareOpsManager manages the lifecycle of all instance and share operations.
 type MultishareOpsManager struct {
-	sync.Mutex       // Lock to perform thread safe multishare operations.
-	cloud            *cloud.Cloud
-	controllerServer *controllerServer
+	sync.Mutex         // Lock to perform thread safe multishare operations.
+	cloud              *cloud.Cloud
+	controllerServer   *controllerServer
+	msControllerServer *MultishareController
 }
 
-func NewMultishareOpsManager(cloud *cloud.Cloud) *MultishareOpsManager {
+func NewMultishareOpsManager(cloud *cloud.Cloud, mcs *MultishareController) *MultishareOpsManager {
 	return &MultishareOpsManager{
-		cloud: cloud,
+		cloud:              cloud,
+		msControllerServer: mcs,
 	}
 }
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -84,7 +84,7 @@ func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	if err != nil {
 		t.Fatalf("Failed to init metadata service")
 	}
-	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, &GCFSDriverFeatureOptions{&FeatureLockRelease{}})
+	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{}})
 	if err != nil {
 		t.Fatalf("Failed to create node server: %v", err)
 	}
@@ -733,7 +733,7 @@ func initBlockingTestNodeServer(t *testing.T, operationUnblocker chan chan struc
 	if err != nil {
 		t.Fatalf("Failed to init metadata service")
 	}
-	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, &GCFSDriverFeatureOptions{&FeatureLockRelease{}})
+	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{}})
 	if err != nil {
 		t.Fatalf("Failed to create node server: %v", err)
 	}

--- a/pkg/util/multishare_defs.go
+++ b/pkg/util/multishare_defs.go
@@ -30,6 +30,9 @@ const (
 	ParamMultishareInstanceScLabelKey       = "storage_gke_io_storage-class-id"
 
 	FilestoreResourceCleanupFinalizer = "multishare.filestore.csi.storage.gke.io/resource-cleanup-protection"
+
+	// configurable max shares consts
+	MinShareSizeConfigurableBytes int64 = 10 * Gb
 )
 
 type OperationType int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Filestore CSI driver will support configurable max number of shares per multishare Filestore instance. This PR sets up the feature gate flag

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Added a backpointer to the multishare controller in the ops manager. this is needed to handle the feature disabled case, where we need to clear the instance.MaxShareCount field in create instance filestore api call. [code](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/pkg/csi_driver/multishare_ops_manager.go#L225)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
setup feature gate for configurable shares per instance
```
