### PR TITLE
Fix pointer issue for lock release controller

### DIFF
--- a/pkg/releaselock/controller.go
+++ b/pkg/releaselock/controller.go
@@ -209,7 +209,7 @@ func (c *LockReleaseController) listNodes(ctx context.Context) (map[string]*core
 	}
 	nodeMap := map[string]*corev1.Node{}
 	for _, node := range nodeList.Items {
-		nodeMap[node.Name] = &node
+		nodeMap[node.Name] = node.DeepCopy()
 	}
 	return nodeMap, nil
 }

--- a/pkg/releaselock/controller_test.go
+++ b/pkg/releaselock/controller_test.go
@@ -1,11 +1,14 @@
 package rpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestVerifyNodeExists(t *testing.T) {
@@ -114,6 +117,51 @@ func TestVerifyNodeExists(t *testing.T) {
 		if nodeExists != test.expectExists {
 			t.Errorf("test %q failed: got nodeExists %t, expected %t", test.name, nodeExists, test.expectExists)
 		}
+	}
+}
+
+func TestListNodes(t *testing.T) {
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				gceInstanceIDKey: "node1-id",
+			},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				gceInstanceIDKey: "node2-id",
+			},
+		},
+	}
+	controller := LockReleaseController{client: fake.NewSimpleClientset(node1, node2)}
+	expectedMap := map[string]*corev1.Node{
+		"node1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Annotations: map[string]string{
+					gceInstanceIDKey: "node1-id",
+				},
+			},
+		},
+		"node2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+				Annotations: map[string]string{
+					gceInstanceIDKey: "node2-id",
+				},
+			},
+		},
+	}
+	nodes, err := controller.listNodes(context.Background())
+	if err != nil {
+		t.Fatalf("test listNodes failed: unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(expectedMap, nodes); diff != "" {
+		t.Errorf("test listNodes failed: unexpected diff (-want +got):%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
There was a bug in listNodes() because of pointer issues, which will cause the lock release controller always determine the node as not exist.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This fix is for lock release feature only
```
