### PR TITLE
Set enterprise tier in backup documentation

### DIFF
--- a/docs/kubernetes/backup.md
+++ b/docs/kubernetes/backup.md
@@ -8,7 +8,7 @@ Kubernetes 1.17+. CSI VolumeSnapshot should not be confused with Filestore Backu
 >**Prerequisites:**: Volume Snapshot CRDs and snapshot-controller needs to be installed for the backup example to work. Please refer to [this](https://kubernetes-csi.github.io/docs/snapshot-controller.html#deployment) for additional details. GKE clusters 1.17+ come pre-installed with the above mentioned CRDs and snapshot controller, see [here](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-snapshots).
 
 ### Backup Example
-A Filestore backup is a copy of a file share that includes all file data and metadata of the file share from the point in time when the backup is created. It works for Basic HDD and Basic SSD tier instances. Once a backup of a file share is created, the original file share can be modified or deleted without affecting the backup. A file share can be completely restored from a backup as a new Filestore instance or onto an existing file share. For more details refer to this [documentation](https://cloud.google.com/filestore/docs/backups)
+A Filestore backup is a copy of a file share that includes all file data and metadata of the file share from the point in time when the backup is created. It works for [Basic HDD, Basic SSD, and Enterprise tier instances](https://cloud.google.com/filestore/docs/service-tiers). The tier and volume size of the backup must match the source volume. Once a backup of a file share is created, the original file share can be modified or deleted without affecting the backup. A file share can be completely restored from a backup as a new Filestore instance or onto an existing file share. For more details refer to this [documentation](https://cloud.google.com/filestore/docs/backups)
 
 The [CSI Snapshot](https://github.com/container-storage-interface/spec/blob/master/spec.md#createsnapshot) feature is leveraged to create Filestore Backups. By specifying a `type: backup` field in the VolumeSnapshotClass parameters, filestore CSI driver understands how to initiate a backup for a Filestore instance backed by the Persistent Volume. In future release when Filestore snapshots will be supported, an appropriate `type` parameter will be set in the VolumeSnapshotClass to indicate Filestore snapshots.
 
@@ -29,6 +29,7 @@ The [CSI Snapshot](https://github.com/container-storage-interface/spec/blob/mast
     name: csi-filestore
     provisioner: filestore.csi.storage.gke.io
     parameters:
+      tier: enterprise
       network: <network name> # Change this network as per the deployment
     volumeBindingMode: WaitForFirstConsumer
     allowVolumeExpansion: true
@@ -82,7 +83,7 @@ The [CSI Snapshot](https://github.com/container-storage-interface/spec/blob/mast
     The output is similar to this:
 
     ```yaml
-    apiVersion: snapshot.storage.k8s.io/v1beta1
+    apiVersion: snapshot.storage.k8s.io/v1
     kind: VolumeSnapshot
     metadata:
     creationTimestamp: "2020-11-13T03:04:03Z"

--- a/examples/kubernetes/backups-restore/backup-volumesnapshotclass.yaml
+++ b/examples/kubernetes/backups-restore/backup-volumesnapshotclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-gcp-filestore-backup-snap-class

--- a/examples/kubernetes/backups-restore/backup.yaml
+++ b/examples/kubernetes/backups-restore/backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: backup-source-pvc

--- a/examples/kubernetes/backups-restore/sc.yaml
+++ b/examples/kubernetes/backups-restore/sc.yaml
@@ -3,5 +3,8 @@ kind: StorageClass
 metadata:
   name: csi-filestore
 provisioner: filestore.csi.storage.gke.io
+parameters:
+  tier: enterprise
 volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
 allowVolumeExpansion: true

--- a/examples/kubernetes/backups/backup-different-region.yaml
+++ b/examples/kubernetes/backups/backup-different-region.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: test-backup-diff-region

--- a/examples/kubernetes/backups/backup-same-region.yaml
+++ b/examples/kubernetes/backups/backup-same-region.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: test-backup-same-region

--- a/examples/kubernetes/backups/backup-volumesnapshotclass-diff-region.yaml
+++ b/examples/kubernetes/backups/backup-volumesnapshotclass-diff-region.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-gcp-filestore-backup-snap-class-diff-region

--- a/examples/kubernetes/backups/backup-volumesnapshotclass-same-region.yaml
+++ b/examples/kubernetes/backups/backup-volumesnapshotclass-same-region.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-gcp-filestore-backup-snap-class-same-region


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Update example documentation to v1 from v1beta. 
Default to `tier: enterprise` instead of basic.
Update supported tier list in [backup.md](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/docs/kubernetes/backup.md)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update example documentation to v1 from v1beta
```
