### PR TITLE
NFS lock release metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 	if *runController {
 		if *httpEndpoint != "" && metrics.IsGKEComponentVersionAvailable() {
 			mm = metrics.NewMetricsManager()
+			mm.RegisterOperationSecondsMetric()
 			mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
 			mm.EmitGKEComponentVersion()
 		}
@@ -139,10 +140,12 @@ func main() {
 		FeatureLockRelease: &driver.FeatureLockRelease{
 			Enabled: *featureLockRelease,
 			Config: &lockrelease.LockReleaseControllerConfig{
-				LeaseDuration: *leaderElectionLeaseDuration,
-				RenewDeadline: *leaderElectionRenewDeadline,
-				RetryPeriod:   *leaderElectionRetryPeriod,
-				SyncPeriod:    *lockReleaseSyncPeriod,
+				LeaseDuration:  *leaderElectionLeaseDuration,
+				RenewDeadline:  *leaderElectionRenewDeadline,
+				RetryPeriod:    *leaderElectionRetryPeriod,
+				SyncPeriod:     *lockReleaseSyncPeriod,
+				MetricEndpoint: *httpEndpoint,
+				MetricPath:     *metricsPath,
 			},
 		},
 		FeatureMaxSharesPerInstance: &driver.FeatureMaxSharesPerInstance{

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/metrics"
 	lockrelease "sigs.k8s.io/gcp-filestore-csi-driver/pkg/releaselock"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
@@ -54,7 +56,6 @@ type nodeServer struct {
 	metaService           metadata.Service
 	volumeLocks           *util.VolumeLocks
 	lockReleaseController *lockrelease.LockReleaseController
-	kubeClient            kubernetes.Interface
 	features              *GCFSDriverFeatureOptions
 }
 
@@ -75,7 +76,6 @@ func newNodeServer(driver *GCFSDriver, mounter mount.Interface, metaService meta
 		if err != nil {
 			return nil, err
 		}
-		ns.kubeClient = client
 		lc, err := lockrelease.NewLockReleaseController(client, ns.features.FeatureLockRelease.Config)
 		if err != nil {
 			return nil, err
@@ -507,11 +507,14 @@ func (s *nodeServer) nodeStageVolumeUpdateLockInfo(ctx context.Context, req *csi
 
 	// Update the configMap after successful nfs mount operation.
 	nodeName := s.driver.config.NodeName
-	configmapName := util.ConfigMapNamePrefix + nodeName
-	klog.Infof("NodeStageVolume getting configmap %s/%s for volume %s", util.ManagedFilestoreCSINamespace, configmapName, volumeID)
-	cm, err := util.GetConfigMap(ctx, configmapName, util.ManagedFilestoreCSINamespace, s.kubeClient)
+	configmapName := lockrelease.ConfigMapNamePrefix + nodeName
+	klog.Infof("NodeStageVolume getting configmap %s/%s for volume %s", lockrelease.ConfigMapNamespace, configmapName, volumeID)
+	start := time.Now()
+	cm, err := s.lockReleaseController.GetConfigMap(ctx, configmapName, lockrelease.ConfigMapNamespace)
+	duration := time.Since(start)
+	s.lockReleaseController.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.GetOpType, metrics.NodeStageOpSource, duration)
 	if err != nil {
-		klog.Errorf("NodeStageVolume failed to get configmap %s/%s for volume %s: %v", util.ManagedFilestoreCSINamespace, configmapName, volumeID, err)
+		klog.Errorf("NodeStageVolume failed to get configmap %s/%s for volume %s: %v", lockrelease.ConfigMapNamespace, configmapName, volumeID, err)
 		return err
 	}
 
@@ -525,18 +528,21 @@ func (s *nodeServer) nodeStageVolumeUpdateLockInfo(ctx context.Context, req *csi
 	filestoreIP := attr[attrIP]
 	if cm == nil {
 		data := map[string]string{lockInfoKey: filestoreIP}
-		klog.Infof("NodeStageVolume creating configmap %s/%s with data %v for volume %s", util.ManagedFilestoreCSINamespace, configmapName, data, volumeID)
-		cm, err := util.CreateConfigMapWithData(ctx, configmapName, util.ManagedFilestoreCSINamespace, data, s.kubeClient)
+		klog.Infof("NodeStageVolume creating configmap %s/%s with data %v for volume %s", lockrelease.ConfigMapNamespace, configmapName, data, volumeID)
+		start := time.Now()
+		cm, err := s.lockReleaseController.CreateConfigMapWithData(ctx, configmapName, lockrelease.ConfigMapNamespace, data)
+		duration := time.Since(start)
+		s.lockReleaseController.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.CreateOpType, metrics.NodeStageOpSource, duration)
 		if err != nil {
-			klog.Errorf("NodeStageVolume failed to create configmap %s/%s with data %s for volume %s: %v", util.ManagedFilestoreCSINamespace, configmapName, data, volumeID, err)
+			klog.Errorf("NodeStageVolume failed to create configmap %s/%s with data %s for volume %s: %v", lockrelease.ConfigMapNamespace, configmapName, data, volumeID, err)
 			return err
 		}
 		klog.Infof("NodeStageVolume successfully created configmap %s/%s with data %v for volume %s", cm.Name, cm.Name, cm.Data, volumeID)
 		return nil
 	}
 
-	if err := util.UpdateConfigMapWithKeyValue(ctx, cm, lockInfoKey, filestoreIP, s.kubeClient); err != nil {
-		klog.Errorf("NodeStageVolume failed to update configmap %s/%s with lock info {%s: %s} for volume %s: %v", util.ManagedFilestoreCSINamespace, configmapName, volumeID, err)
+	if err := s.lockReleaseController.UpdateConfigMapWithKeyValue(ctx, cm, lockInfoKey, filestoreIP); err != nil {
+		klog.Errorf("NodeStageVolume failed to update configmap %s/%s with lock info {%s: %s} for volume %s: %v", lockrelease.ConfigMapNamespace, configmapName, volumeID, err)
 		return err
 	}
 
@@ -547,15 +553,18 @@ func (s *nodeServer) nodeStageVolumeUpdateLockInfo(ctx context.Context, req *csi
 func (s *nodeServer) nodeUnstageVolumeUpdateLockInfo(ctx context.Context, req *csi.NodeUnstageVolumeRequest) error {
 	volumeID := req.GetVolumeId()
 	nodeName := s.driver.config.NodeName
-	configmapName := util.ConfigMapNamePrefix + nodeName
-	klog.Infof("NodeUnstageVolume getting configmap %s/%s for volume %s", util.ManagedFilestoreCSINamespace, configmapName, volumeID)
-	cm, err := util.GetConfigMap(ctx, configmapName, util.ManagedFilestoreCSINamespace, s.kubeClient)
+	configmapName := lockrelease.ConfigMapNamePrefix + nodeName
+	klog.Infof("NodeUnstageVolume getting configmap %s/%s for volume %s", lockrelease.ConfigMapNamespace, configmapName, volumeID)
+	start := time.Now()
+	cm, err := s.lockReleaseController.GetConfigMap(ctx, configmapName, lockrelease.ConfigMapNamespace)
+	duration := time.Since(start)
+	s.lockReleaseController.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.GetOpType, metrics.NodeUnstageOpSource, duration)
 	if err != nil {
-		klog.Errorf("NodeStageVolume failed to get configmap %s/%s for volume %s: %v", util.ManagedFilestoreCSINamespace, configmapName, volumeID, err)
+		klog.Errorf("NodeStageVolume failed to get configmap %s/%s for volume %s: %v", lockrelease.ConfigMapNamespace, configmapName, volumeID, err)
 		return err
 	}
 	if cm == nil {
-		klog.Infof("NodeUnstageVolume skipped updating lock info for volume %s: configmap %s/%s not found", volumeID, util.ManagedFilestoreCSINamespace, configmapName)
+		klog.Infof("NodeUnstageVolume skipped updating lock info for volume %s: configmap %s/%s not found", volumeID, lockrelease.ConfigMapNamespace, configmapName)
 		return nil
 	}
 
@@ -565,7 +574,7 @@ func (s *nodeServer) nodeUnstageVolumeUpdateLockInfo(ctx context.Context, req *c
 		return err
 	}
 
-	if err := util.RemoveKeyFromConfigMap(ctx, cm, lockInfoKey, s.kubeClient); err != nil {
+	if err := s.lockReleaseController.RemoveKeyFromConfigMap(ctx, cm, lockInfoKey); err != nil {
 		klog.Infof("NodeUnstageVolume failed to remove key %s from configmap %s/%s for volume %s: %v", lockInfoKey, cm.Namespace, cm.Name, volumeID, err)
 		return err
 	}
@@ -586,7 +595,7 @@ func (s *nodeServer) generateLockInfoKeyFromVolumeID(volumeID string) (string, e
 		if err != nil {
 			return "", err
 		}
-		lockInfoKey = util.GenerateConfigMapKey(project, location, filestoreName, shareName, nodeID, nodeInternalIP)
+		lockInfoKey = lockrelease.GenerateConfigMapKey(project, location, filestoreName, shareName, nodeID, nodeInternalIP)
 		return lockInfoKey, nil
 	}
 
@@ -595,6 +604,6 @@ func (s *nodeServer) generateLockInfoKeyFromVolumeID(volumeID string) (string, e
 		return "", err
 	}
 	project := s.metaService.GetProject()
-	lockInfoKey = util.GenerateConfigMapKey(project, filestoreInstance.Location, filestoreInstance.Name, filestoreInstance.Volume.Name, nodeID, nodeInternalIP)
+	lockInfoKey = lockrelease.GenerateConfigMapKey(project, filestoreInstance.Location, filestoreInstance.Name, filestoreInstance.Volume.Name, nodeID, nodeInternalIP)
 	return lockInfoKey, nil
 }

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	mount "k8s.io/mount-utils"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
+	lockrelease "sigs.k8s.io/gcp-filestore-csi-driver/pkg/releaselock"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
 
@@ -101,12 +102,12 @@ func initTestNodeServerWithKubeClient(t *testing.T, client kubernetes.Interface)
 		t.Fatalf("Failed to init metadata service")
 	}
 	return &nodeServer{
-		driver:      initTestDriver(t),
-		mounter:     mounter,
-		metaService: metaserice,
-		volumeLocks: util.NewVolumeLocks(),
-		kubeClient:  client,
-		features:    &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{Enabled: true}},
+		driver:                initTestDriver(t),
+		mounter:               mounter,
+		metaService:           metaserice,
+		volumeLocks:           util.NewVolumeLocks(),
+		lockReleaseController: lockrelease.NewFakeLockReleaseControllerWithClient(client),
+		features:              &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{Enabled: true}},
 	}
 }
 
@@ -908,8 +909,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -918,8 +919,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -937,8 +938,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node-1",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.1234567.127_0_0_2": "1.1.1.1",
@@ -947,8 +948,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -966,8 +967,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
@@ -976,8 +977,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
@@ -996,8 +997,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -1006,8 +1007,8 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -1055,8 +1056,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-filestore.vol1.123456.127_0_0_1": "1.1.1.2",
@@ -1066,8 +1067,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-filestore.vol1.123456.127_0_0_1": "1.1.1.2",
@@ -1083,8 +1084,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-filestore.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -1093,8 +1094,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-filestore.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -1110,8 +1111,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			existingCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{
 					"test-project.us-central1-c.test-csi.vol1.123456.127_0_0_1": "1.1.1.1",
@@ -1120,8 +1121,8 @@ func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "fscsi-test-node",
-					Namespace:  util.ManagedFilestoreCSINamespace,
-					Finalizers: []string{util.ConfigMapFinalzer},
+					Namespace:  lockrelease.ConfigMapNamespace,
+					Finalizers: []string{lockrelease.ConfigMapFinalzer},
 				},
 				Data: map[string]string{},
 			},

--- a/pkg/releaselock/configmap_util.go
+++ b/pkg/releaselock/configmap_util.go
@@ -11,20 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package lockrelease
 
 import (
 	"context"
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/metrics"
 )
 
 // Ordering of elements in configmap key
@@ -42,6 +43,7 @@ const (
 
 const (
 	ConfigMapNamePrefix = "fscsi-"
+	ConfigMapNamespace  = "gke-managed-filestorecsi"
 
 	// ConfigMapFinalzer is the finalizer which will be added during configmap creation.
 	ConfigMapFinalzer = "filestore.csi.storage.gke.io/lock-release"
@@ -100,8 +102,8 @@ func GKENodeNameFromConfigMap(cm *corev1.ConfigMap) (string, error) {
 
 // GetConfigMap gets the configmap from the api server.
 // Returns nil if the expected configmap is not found.
-func GetConfigMap(ctx context.Context, cmName, cmNamespace string, client kubernetes.Interface) (*corev1.ConfigMap, error) {
-	cm, err := client.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
+func (c *LockReleaseController) GetConfigMap(ctx context.Context, cmName, cmNamespace string) (*corev1.ConfigMap, error) {
+	cm, err := c.client.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
 	if err != nil {
 		if apiError.IsNotFound(err) {
 			return nil, nil
@@ -113,7 +115,7 @@ func GetConfigMap(ctx context.Context, cmName, cmNamespace string, client kubern
 
 // CreateConfigMapWithData creates a configmap in the api server.
 // Returns the api server's representation of the configmap, and an error, if there is any.
-func CreateConfigMapWithData(ctx context.Context, cmName, cmNamespace string, data map[string]string, client kubernetes.Interface) (*corev1.ConfigMap, error) {
+func (c *LockReleaseController) CreateConfigMapWithData(ctx context.Context, cmName, cmNamespace string, data map[string]string) (*corev1.ConfigMap, error) {
 	obj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       cmName,
@@ -122,7 +124,7 @@ func CreateConfigMapWithData(ctx context.Context, cmName, cmNamespace string, da
 		},
 		Data: data,
 	}
-	cm, err := client.CoreV1().ConfigMaps(cmNamespace).Create(ctx, obj, metav1.CreateOptions{})
+	cm, err := c.client.CoreV1().ConfigMaps(cmNamespace).Create(ctx, obj, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,8 @@ func CreateConfigMapWithData(ctx context.Context, cmName, cmNamespace string, da
 // UpdateConfigMapWithKeyValue adds a key value pair into configmap.data, and updates the configmap in the api server.
 // No-op if the key already exists in configmap.data.
 // Returns the server's representation of the configMap, and an error, if there is any.
-func UpdateConfigMapWithKeyValue(ctx context.Context, cm *corev1.ConfigMap, key, value string, client kubernetes.Interface) error {
+// UpdateConfigMapWithKeyValue is only called in NodeStageVolume.
+func (c *LockReleaseController) UpdateConfigMapWithKeyValue(ctx context.Context, cm *corev1.ConfigMap, key, value string) error {
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}
@@ -143,7 +146,10 @@ func UpdateConfigMapWithKeyValue(ctx context.Context, cm *corev1.ConfigMap, key,
 	}
 	klog.Infof("NodeStageVolume storing lock info {%s: %s} in configmap %s/%s with data %v", key, value, cm.Namespace, cm.Name, cm.Data)
 	cm.Data[key] = value
-	updatedCM, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	start := time.Now()
+	updatedCM, err := c.client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	duration := time.Since(start)
+	c.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.UpdateOpType, metrics.NodeStageOpSource, duration)
 	if err != nil {
 		return err
 	}
@@ -153,7 +159,8 @@ func UpdateConfigMapWithKeyValue(ctx context.Context, cm *corev1.ConfigMap, key,
 
 // RemoveKeyFromConfigMap deletes the key from configmap.data, then updates the configmap.
 // No-op if the key does not exist.
-func RemoveKeyFromConfigMap(ctx context.Context, cm *corev1.ConfigMap, key string, client kubernetes.Interface) error {
+// RemoveKeyFromConfigMap is only called in NodeUnstageVolume.
+func (c *LockReleaseController) RemoveKeyFromConfigMap(ctx context.Context, cm *corev1.ConfigMap, key string) error {
 	if _, keyExists := cm.Data[key]; !keyExists {
 		klog.Infof("NodeUnstageVolume skipped updating configmap %s/%s since key %s not found in configmap.data", cm.Namespace, cm.Name, key)
 		return nil
@@ -161,7 +168,10 @@ func RemoveKeyFromConfigMap(ctx context.Context, cm *corev1.ConfigMap, key strin
 
 	klog.Infof("NodeUnstageVolume removing key %s from configmap %s/%s with data %v", key, cm.Namespace, cm.Name, cm.Data)
 	delete(cm.Data, key)
-	updatedCM, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	start := time.Now()
+	updatedCM, err := c.client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	duration := time.Since(start)
+	c.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.UpdateOpType, metrics.NodeUnstageOpSource, duration)
 	if err != nil {
 		return err
 	}
@@ -173,9 +183,13 @@ func RemoveKeyFromConfigMap(ctx context.Context, cm *corev1.ConfigMap, key strin
 // removes the key from configmap.data, and update the configmap.
 // Keeps retrying until configmap successfully update or timeout.
 // No-op if the key does not exist.
-func RemoveKeyFromConfigMapWithRetry(ctx context.Context, cm *corev1.ConfigMap, key string, client kubernetes.Interface) error {
+// RemoveKeyFromConfigMapWithRetry is only called in lock release reconciler.
+func (c *LockReleaseController) RemoveKeyFromConfigMapWithRetry(ctx context.Context, cm *corev1.ConfigMap, key string) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latestCM, err := client.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+		start := time.Now()
+		latestCM, err := c.client.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+		duration := time.Since(start)
+		c.RecordKubeAPIMetrics(err, metrics.ConfigMapResourceType, metrics.GetOpType, metrics.ReconcilerOpSource, duration)
 		if err != nil {
 			return err
 		}
@@ -184,7 +198,10 @@ func RemoveKeyFromConfigMapWithRetry(ctx context.Context, cm *corev1.ConfigMap, 
 			return nil
 		}
 		delete(latestCM.Data, key)
-		_, updateErr := client.CoreV1().ConfigMaps(latestCM.Namespace).Update(ctx, latestCM, metav1.UpdateOptions{})
+		start = time.Now()
+		_, updateErr := c.client.CoreV1().ConfigMaps(latestCM.Namespace).Update(ctx, latestCM, metav1.UpdateOptions{})
+		duration = time.Since(start)
+		c.RecordKubeAPIMetrics(updateErr, metrics.ConfigMapResourceType, metrics.UpdateOpType, metrics.ReconcilerOpSource, duration)
 		return updateErr
 	})
 }

--- a/pkg/releaselock/configmap_util_test.go
+++ b/pkg/releaselock/configmap_util_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package lockrelease
 
 import (
 	"context"
@@ -179,7 +179,8 @@ func TestGetConfigMap(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
-		cm, err := GetConfigMap(context.Background(), test.cmName, test.cmNamespace, client)
+		controller := NewFakeLockReleaseControllerWithClient(client)
+		cm, err := controller.GetConfigMap(context.Background(), test.cmName, test.cmNamespace)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
 		}
@@ -273,12 +274,13 @@ func TestUpdateConfigMapWithKeyValue(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
+		controller := NewFakeLockReleaseControllerWithClient(client)
 		ctx := context.Background()
-		err := UpdateConfigMapWithKeyValue(ctx, test.existingCM, test.key, test.value, client)
+		err := controller.UpdateConfigMapWithKeyValue(ctx, test.existingCM, test.key, test.value)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
 		}
-		updatedCM, err := GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace, client)
+		updatedCM, err := controller.GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace)
 		if err != nil {
 			t.Fatalf("test %q failed: unexpected error: %v", test.name, err)
 		}
@@ -370,12 +372,13 @@ func TestRemoveKeyFromConfigMap(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
+		controller := NewFakeLockReleaseControllerWithClient(client)
 		ctx := context.Background()
-		err := RemoveKeyFromConfigMap(ctx, test.existingCM, test.key, client)
+		err := controller.RemoveKeyFromConfigMap(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
 		}
-		updatedCM, err := GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace, client)
+		updatedCM, err := controller.GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace)
 		if err != nil {
 			t.Fatalf("test %q failed: unexpected error: %v", test.name, err)
 		}
@@ -467,12 +470,13 @@ func TestRemoveKeyFromConfigMapWithRetry(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
+		controller := NewFakeLockReleaseControllerWithClient(client)
 		ctx := context.Background()
-		err := RemoveKeyFromConfigMapWithRetry(ctx, test.existingCM, test.key, client)
+		err := controller.RemoveKeyFromConfigMapWithRetry(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
 		}
-		updatedCM, err := GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace, client)
+		updatedCM, err := controller.GetConfigMap(ctx, test.expectedCM.Name, test.expectedCM.Namespace)
 		if err != nil {
 			t.Fatalf("test %q failed: unexpected error: %v", test.name, err)
 		}

--- a/pkg/releaselock/controller_test.go
+++ b/pkg/releaselock/controller_test.go
@@ -1,8 +1,7 @@
-package rpc
+package lockrelease
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -109,7 +108,7 @@ func TestVerifyNodeExists(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		controller := LockReleaseController{}
+		controller := NewFakeLockReleaseController()
 		nodeExists, err := controller.verifyNodeExists(test.node, test.gceInstanceID, test.nodeInternalIP)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Errorf("%v", gotExpected)
@@ -137,7 +136,7 @@ func TestListNodes(t *testing.T) {
 			},
 		},
 	}
-	controller := LockReleaseController{client: fake.NewSimpleClientset(node1, node2)}
+	controller := NewFakeLockReleaseControllerWithClient(fake.NewSimpleClientset(node1, node2))
 	expectedMap := map[string]*corev1.Node{
 		"node1": {
 			ObjectMeta: metav1.ObjectMeta{
@@ -163,14 +162,4 @@ func TestListNodes(t *testing.T) {
 	if diff := cmp.Diff(expectedMap, nodes); diff != "" {
 		t.Errorf("test listNodes failed: unexpected diff (-want +got):%s", diff)
 	}
-}
-
-func gotExpectedError(testFunc string, wantErr bool, err error) error {
-	if err != nil && !wantErr {
-		return fmt.Errorf("%s got error %v, want nil", testFunc, err)
-	}
-	if err == nil && wantErr {
-		return fmt.Errorf("%s got nil, want error", testFunc)
-	}
-	return nil
 }

--- a/pkg/releaselock/fake.go
+++ b/pkg/releaselock/fake.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lockrelease
+
+import "k8s.io/client-go/kubernetes"
+
+func NewFakeLockReleaseController() *LockReleaseController {
+	return &LockReleaseController{}
+}
+
+func NewFakeLockReleaseControllerWithClient(client kubernetes.Interface) *LockReleaseController {
+	return &LockReleaseController{client: client}
+}

--- a/pkg/releaselock/rpc.go
+++ b/pkg/releaselock/rpc.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rpc
+package lockrelease
 
 import (
 	"encoding/binary"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
kind feature
> /kind flake

**What this PR does / why we need it**:
Implement NFS lock release metrics:
1. kube api op latency
2. lock release count

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Example: ssh to the node which has the volume mounted, then run command `curl localhost:22026/metrics`. The results are
```
tyuchn@gke-nfs-lock-default-pool-d4c7d43a-ey69 ~ $ curl localhost:22026/metrics
# HELP filestorecsi_kube_api_duration_seconds [ALPHA] Metric to expose duration of node driver initiated k8s API operations.
# TYPE filestorecsi_kube_api_duration_seconds histogram
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="8"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="16"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="32"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="64"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="128"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="256"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="512"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="1024"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="+Inf"} 2
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap"} 15
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="8"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="16"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="32"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="64"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="128"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="256"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="512"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="1024"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="+Inf"} 2
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node"} 49
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="8"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="16"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="32"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="64"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="128"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="256"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="512"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="1024"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap",le="+Inf"} 1
filestorecsi_kube_api_duration_seconds_sum{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap"} 6
filestorecsi_kube_api_duration_seconds_count{op_source="node_stage_volume",op_status_code="success",op_type="get",resource_type="configmap"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="8"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="16"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="32"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="64"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="128"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="256"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="512"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="1024"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap",le="+Inf"} 1
filestorecsi_kube_api_duration_seconds_sum{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap"} 7
filestorecsi_kube_api_duration_seconds_count{op_source="node_stage_volume",op_status_code="success",op_type="update",resource_type="configmap"} 1
# HELP process_start_time_seconds [ALPHA] Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.6827103635e+09
```
Then manually delete the VM, see lock release metrics as the following
```
tyuchn@gke-nfs-lock-default-pool-d4c7d43a-3k8v ~ $ curl localhost:22026/metrics
# HELP filestorecsi_kube_api_duration_seconds [ALPHA] Metric to expose duration of node driver initiated k8s API operations.
# TYPE filestorecsi_kube_api_duration_seconds histogram
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="8"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="16"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="32"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="64"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="128"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="256"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="512"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="1024"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap",le="+Inf"} 1
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap"} 7
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="get",resource_type="configmap"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="4"} 2
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="8"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="16"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="32"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="64"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="128"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="256"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="512"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="1024"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap",le="+Inf"} 5
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap"} 23
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="configmap"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="8"} 3
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="16"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="32"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="64"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="128"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="256"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="512"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="1024"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node",le="+Inf"} 5
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node"} 39
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="list",resource_type="node"} 5
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="1"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="2"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="4"} 0
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="8"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="16"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="32"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="64"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="128"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="256"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="512"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="1024"} 1
filestorecsi_kube_api_duration_seconds_bucket{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap",le="+Inf"} 1
filestorecsi_kube_api_duration_seconds_sum{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap"} 5
filestorecsi_kube_api_duration_seconds_count{op_source="lock_release_reconciler",op_status_code="success",op_type="update",resource_type="configmap"} 1
# HELP filestorecsi_lock_release_count [ALPHA] Metric to expose count of node driver initiated filestore lock release operations.
# TYPE filestorecsi_lock_release_count counter
filestorecsi_lock_release_count{status_code="success"} 1
# HELP process_start_time_seconds [ALPHA] Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.68271036524e+09
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
