### PR TITLE
Replace PollOpErrorCode and IsUserError with CodeForError

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
@@ -636,7 +637,7 @@ func IsNotFoundErr(err error) bool {
 	return false
 }
 
-// IsUserError returns a pointer to the grpc error code that maps to the http
+// isUserError returns a pointer to the grpc error code that maps to the http
 // error code for the passed in user googleapi error. Returns nil if the
 // given error is not a googleapi error caused by the user. The following
 // http error codes are considered user errors:
@@ -644,7 +645,7 @@ func IsNotFoundErr(err error) bool {
 // (2) http 403 Forbidden, returns grpc PermissionDenied,
 // (3) http 404 Not Found, returns grpc NotFound
 // (4) http 429 Too Many Requests, returns grpc ResourceExhausted
-func IsUserError(err error) *codes.Code {
+func isUserError(err error) *codes.Code {
 	// Upwrap the error
 	var apiErr *googleapi.Error
 	if !errors.As(err, &apiErr) {
@@ -663,10 +664,10 @@ func IsUserError(err error) *codes.Code {
 	return nil
 }
 
-// IsContextError returns a pointer to the grpc error code DeadlineExceeded
+// isContextError returns a pointer to the grpc error code DeadlineExceeded
 // if the passed in error contains the "context deadline exceeded" string and returns
 // the grpc error code Canceled if the error contains the "context canceled" string.
-func IsContextError(err error) *codes.Code {
+func isContextError(err error) *codes.Code {
 	if err == nil {
 		return nil
 	}
@@ -681,17 +682,41 @@ func IsContextError(err error) *codes.Code {
 	return nil
 }
 
-// PollOpErrorCode returns a pointer to the grpc error code that maps to the http
-// error code for passed in googleapi error. Returns grpc DeadlineExceeded if the
-// given error contains the "context deadline exceeded" string. Returns the grpc Internal error
-// code if the passed in error is neither a user error or a deadline exceeded error.
-func PollOpErrorCode(err error) *codes.Code {
-	if errCode := IsUserError(err); errCode != nil {
+// existingErrorCode returns a pointer to the grpc error code for the passed in error.
+// Returns nil if the error is nil, or if the error cannot be converted to a grpc status.
+func existingErrorCode(err error) *codes.Code {
+	if err == nil {
+		return nil
+	}
+
+	if status, ok := status.FromError(err); ok {
+		return util.ErrCodePtr(status.Code())
+	}
+	return nil
+}
+
+// CodeForError returns a pointer to the grpc error code that maps to the http
+// error code for the passed in user googleapi error or context error. Returns
+// codes.Internal if the given error is not a googleapi error caused by the user.
+// The following http error codes are considered user errors:
+// (1) http 400 Bad Request, returns grpc InvalidArgument,
+// (2) http 403 Forbidden, returns grpc PermissionDenied,
+// (3) http 404 Not Found, returns grpc NotFound
+// (4) http 429 Too Many Requests, returns grpc ResourceExhausted
+// The following errors are considered context errors:
+// (1) "context deadline exceeded", returns grpc DeadlineExceeded,
+// (2) "context canceled", returns grpc Canceled
+func CodeForError(err error) *codes.Code {
+	if errCode := existingErrorCode(err); errCode != nil {
 		return errCode
 	}
-	if errCode := IsContextError(err); errCode != nil {
+	if errCode := isUserError(err); errCode != nil {
 		return errCode
 	}
+	if errCode := isContextError(err); errCode != nil {
+		return errCode
+	}
+
 	return util.ErrCodePtr(codes.Internal)
 }
 

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 )
 
@@ -524,7 +525,7 @@ func TestIsContextError(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		errCode := IsContextError(test.err)
+		errCode := isContextError(test.err)
 		if (test.expectedErrCode == nil) != (errCode == nil) {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
 		}
@@ -534,7 +535,7 @@ func TestIsContextError(t *testing.T) {
 	}
 }
 
-func TestPollOpErrorCode(t *testing.T) {
+func TestCodeForError(t *testing.T) {
 	cases := []struct {
 		name            string
 		err             error
@@ -575,10 +576,15 @@ func TestPollOpErrorCode(t *testing.T) {
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusNotFound}),
 			expectedErrCode: util.ErrCodePtr(codes.NotFound),
 		},
+		{
+			name:            "status error with Aborted error code",
+			err:             status.Error(codes.Aborted, "aborted error"),
+			expectedErrCode: util.ErrCodePtr(codes.Aborted),
+		},
 	}
 
 	for _, test := range cases {
-		errCode := PollOpErrorCode(test.err)
+		errCode := CodeForError(test.err)
 		if (test.expectedErrCode == nil) != (errCode == nil) {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
 		}
@@ -627,7 +633,7 @@ func TestIsUserError(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		errCode := IsUserError(test.err)
+		errCode := isUserError(test.err)
 		if (test.expectedErrCode == nil) != (errCode == nil) {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
 		}

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -213,10 +213,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			_, err = s.config.fileService.GetBackup(ctx, id)
 			if err != nil {
 				klog.Errorf("Failed to get volume %v source snapshot %v: %v", name, id, err.Error())
-				if errCode := file.IsUserError(err); errCode != nil {
-					return nil, status.Error(*errCode, err.Error())
-				}
-				return nil, status.Errorf(codes.Internal, "Failed to get snapshot %v: %v", id, err.Error())
+				return nil, status.Error(*file.CodeForError(err), err.Error())
 			}
 			sourceSnapshotId = id
 		}
@@ -226,10 +223,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 	filer, err := s.config.fileService.GetInstance(ctx, newFiler)
 	// No error is returned if the instance is not found during CreateVolume.
 	if err != nil && !file.IsNotFoundErr(err) {
-		if errCode := file.IsUserError(err); errCode != nil {
-			return nil, status.Error(*errCode, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	if filer != nil {
@@ -291,10 +285,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 		if createErr != nil {
 			klog.Errorf("Create volume for volume Id %s failed: %v", volumeID, createErr.Error())
-			if errCode := file.IsUserError(createErr); errCode != nil {
-				return nil, status.Error(*errCode, createErr.Error())
-			}
-			return nil, status.Error(codes.Internal, createErr.Error())
+			return nil, status.Error(*file.CodeForError(err), err.Error())
 		}
 	}
 	resp := &csi.CreateVolumeResponse{Volume: s.fileInstanceToCSIVolume(filer, modeInstance, sourceSnapshotId)}
@@ -394,10 +385,7 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 		if file.IsNotFoundErr(err) {
 			return &csi.DeleteVolumeResponse{}, nil
 		}
-		if errCode := file.IsUserError(err); errCode != nil {
-			return nil, status.Error(*errCode, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	if filer.State == "DELETING" {
@@ -407,7 +395,7 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 	err = s.config.fileService.DeleteInstance(ctx, filer)
 	if err != nil {
 		klog.Errorf("Delete volume for volume Id %s failed: %v", volumeID, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	klog.Infof("DeleteVolume succeeded for volume %v", volumeID)
@@ -434,10 +422,7 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 	filer.Project = s.config.cloud.Project
 	newFiler, err := s.config.fileService.GetInstance(ctx, filer)
 	if err != nil && !file.IsNotFoundErr(err) {
-		if errCode := file.IsUserError(err); errCode != nil {
-			return nil, status.Error(*errCode, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 	if newFiler == nil {
 		return nil, status.Errorf(codes.NotFound, "volume %v doesn't exist", volumeID)
@@ -697,10 +682,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	filer.Project = s.config.cloud.Project
 	filer, err = s.config.fileService.GetInstance(ctx, filer)
 	if err != nil {
-		if errCode := file.IsUserError(err); errCode != nil {
-			return nil, status.Error(*errCode, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 	if filer.State != "READY" {
 		return nil, fmt.Errorf("lolume %q is not yet ready, current state %q", volumeID, filer.State)
@@ -716,7 +698,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 
 	hasPendingOps, err := s.config.fileService.HasOperations(ctx, filer, "update", false /* done */)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	if hasPendingOps {
@@ -726,7 +708,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	filer.Volume.SizeBytes = reqBytes
 	newfiler, err := s.config.fileService.ResizeInstance(ctx, filer)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	klog.Infof("Controller expand volume succeeded for volume %v, new size(bytes): %v", volumeID, newfiler.Volume.SizeBytes)
@@ -893,7 +875,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	backupInfo, err := s.config.fileService.GetBackup(ctx, backupUri)
 	if err != nil {
 		if !file.IsNotFoundErr(err) {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Error(*file.CodeForError(err), err.Error())
 		}
 	} else {
 		backupSourceCSIHandle, err := util.BackupVolumeSourceToCSIVolumeHandle(backupInfo.SourceInstance, backupInfo.SourceShare)
@@ -930,10 +912,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	if err != nil {
 		klog.Errorf("Create snapshot for volume Id %s failed: %v", volumeID, err.Error())
 		if err != nil {
-			if errCode := file.IsUserError(err); errCode != nil {
-				return nil, status.Error(*errCode, err.Error())
-			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Error(*file.CodeForError(err), err.Error())
 		}
 	}
 	tp, err := util.ParseTimestamp(backupObj.CreateTime)
@@ -977,7 +956,7 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 			klog.Infof("Volume snapshot with ID %v not found", id)
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	if backupInfo.Backup.State == "DELETING" {
@@ -986,7 +965,7 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 
 	if err = s.config.fileService.DeleteBackup(ctx, id); err != nil {
 		klog.Errorf("Delete snapshot for backup Id %s failed: %v", id, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(*file.CodeForError(err), err.Error())
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -183,8 +183,7 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 	// lock released. poll for op.
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		errCode := file.PollOpErrorCode(err)
-		return nil, status.Errorf(*errCode, "Create Volume failed, operation %q poll error: %v", workflow.opName, err)
+		return nil, status.Errorf(*file.CodeForError(err), "Create Volume failed, operation %q poll error: %v", workflow.opName, err)
 	}
 
 	klog.Infof("Poll for operation %s (type %s) completed", workflow.opName, workflow.opType.String())
@@ -211,8 +210,7 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 	// lock released. poll for share create op.
 	err = m.waitOnWorkflow(ctx, shareCreateWorkflow)
 	if err != nil {
-		errCode := file.PollOpErrorCode(err)
-		return nil, status.Errorf(*errCode, "%s operation %q poll error: %v", shareCreateWorkflow.opType.String(), shareCreateWorkflow.opName, err)
+		return nil, status.Errorf(*file.CodeForError(err), "%s operation %q poll error: %v", shareCreateWorkflow.opType.String(), shareCreateWorkflow.opName, err)
 	}
 	return m.getShareAndGenerateCSICreateVolumeResponse(ctx, instanceScPrefix, newShare, maxShareSizeSizeBytes)
 }
@@ -271,8 +269,7 @@ func (m *MultishareController) DeleteVolume(ctx context.Context, req *csi.Delete
 	if workflow != nil {
 		err = m.waitOnWorkflow(ctx, workflow)
 		if err != nil {
-			errCode := file.PollOpErrorCode(err)
-			return nil, status.Errorf(*errCode, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
+			return nil, status.Errorf(*file.CodeForError(err), "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
 		}
 	}
 
@@ -306,8 +303,7 @@ func (m *MultishareController) startAndWaitForInstanceDeleteOrShrink(ctx context
 	}
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		errCode := file.PollOpErrorCode(err)
-		return status.Errorf(*errCode, "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
+		return status.Errorf(*file.CodeForError(err), "%s operation %q poll error: %v", workflow.opType.String(), workflow.opName, err)
 	}
 	return nil
 }
@@ -379,8 +375,7 @@ func (m *MultishareController) ControllerExpandVolume(ctx context.Context, req *
 
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		errCode := file.PollOpErrorCode(err)
-		return nil, status.Errorf(*errCode, "wait on %s operation %q failed with error: %v", workflow.opType.String(), workflow.opName, err)
+		return nil, status.Errorf(*file.CodeForError(err), "wait on %s operation %q failed with error: %v", workflow.opType.String(), workflow.opName, err)
 	}
 	klog.Infof("Wait for operation %s (type %s) completed", workflow.opName, workflow.opType.String())
 
@@ -398,8 +393,7 @@ func (m *MultishareController) ControllerExpandVolume(ctx context.Context, req *
 
 	err = m.waitOnWorkflow(ctx, workflow)
 	if err != nil {
-		errCode := file.PollOpErrorCode(err)
-		return nil, status.Errorf(*errCode, "wait on share expansion op %q failed with error: %v", workflow.opName, err)
+		return nil, status.Errorf(*file.CodeForError(err), "wait on share expansion op %q failed with error: %v", workflow.opName, err)
 	}
 
 	return m.getShareAndGenerateCSIControllerExpandVolumeResponse(ctx, share, reqBytes)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Replace PollOpErrorCode and IsUserError with CodeForError, and filter out User errors from ControllerExpandVolume.This makes things more concise, and closely models what is done in the PDCSI driver. This will be followed up by a PR that filters out the rest of the context / user errors from the multishare controller. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
