### PR TITLE
Use CodeForError when we call filestore API

### DIFF
--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -581,15 +581,46 @@ func TestCodeForError(t *testing.T) {
 			err:             status.Error(codes.Aborted, "aborted error"),
 			expectedErrCode: util.ErrCodePtr(codes.Aborted),
 		},
+		{
+			name:            "nil error",
+			err:             nil,
+			expectedErrCode: nil,
+		},
 	}
 
 	for _, test := range cases {
-		errCode := CodeForError(test.err)
+		errCode := codeForError(test.err)
 		if (test.expectedErrCode == nil) != (errCode == nil) {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
 		}
 		if test.expectedErrCode != nil && *errCode != *test.expectedErrCode {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
+		}
+	}
+}
+
+func TestStatusError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		expectedErr error
+	}{
+		{
+			name:        "404 googleapi error",
+			err:         &googleapi.Error{Code: http.StatusNotFound},
+			expectedErr: status.Error(codes.NotFound, ""),
+		},
+		{
+			name:        "nil error",
+			err:         nil,
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range cases {
+		err := StatusError(test.err)
+		if (test.expectedErr == nil) != (err == nil) {
+			t.Errorf("test %v failed: got %v, expected %v", test.name, err, test.expectedErr)
 		}
 	}
 }

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -1219,7 +1219,7 @@ func TestMultishareDeleteVolume(t *testing.T) {
 		errorExpected bool
 	}{
 		{
-			name: "share not found, instance not found, succes response",
+			name: "share not found, instance not found, success response",
 			req: &csi.DeleteVolumeRequest{
 				VolumeId: testVolId,
 			},

--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -73,7 +73,7 @@ func (m *MultishareOpsManager) setupEligibleInstanceAndStartWorkflow(ctx context
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, nil, status.Error(codes.Internal, err.Error())
+		return nil, nil, err
 	}
 	createShareOp := containsOpWithShareName(shareName, util.ShareCreate, ops)
 	if createShareOp != nil {
@@ -117,7 +117,7 @@ func (m *MultishareOpsManager) setupEligibleInstanceAndStartWorkflow(ctx context
 
 		needExpand, targetBytes, err := m.instanceNeedsExpand(ctx, share, share.CapacityBytes)
 		if err != nil {
-			return nil, nil, status.Error(codes.Internal, err.Error())
+			return nil, nil, err
 		}
 
 		if needExpand {
@@ -204,7 +204,7 @@ func (m *MultishareOpsManager) startShareCreateWorkflowSafe(ctx context.Context,
 	defer m.Unlock()
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return m.startShareWorkflow(ctx, &Workflow{share: share, opType: util.ShareCreate}, ops)
@@ -458,7 +458,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceOrShareExpandWorkflow(ctx co
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	expandShareOp, err := containsOpWithShareTarget(share, util.ShareUpdate, ops)
@@ -478,12 +478,12 @@ func (m *MultishareOpsManager) checkAndStartInstanceOrShareExpandWorkflow(ctx co
 
 	instance, err := m.cloud.File.GetMultishareInstance(ctx, share.Parent)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	needExpand, targetBytes, err := m.instanceNeedsExpand(ctx, share, reqBytes-share.CapacityBytes)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	if needExpand {
 		instance.CapacityBytes = targetBytes
@@ -500,7 +500,7 @@ func (m *MultishareOpsManager) startShareExpandWorkflowSafe(ctx context.Context,
 	defer m.Unlock()
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	share.CapacityBytes = reqBytes
@@ -513,7 +513,7 @@ func (m *MultishareOpsManager) checkAndStartShareDeleteWorkflow(ctx context.Cont
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	// If we find a running delete share op, poll for that to complete.
@@ -534,7 +534,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	err = m.verifyNoRunningInstanceOrShareOpsForInstance(instance, ops)
@@ -551,7 +551,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 		if file.IsNotFoundErr(err) {
 			return nil, nil
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	shares, err := m.cloud.File.ListShares(ctx, &file.ListFilter{Project: instance.Project, Location: instance.Location, InstanceName: instance.Name})
@@ -559,7 +559,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 		if file.IsNotFoundErr(err) {
 			return nil, nil
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	// Check for delete
@@ -569,7 +569,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 			if file.IsNotFoundErr(err) {
 				return nil, nil
 			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		return w, err
 	}
@@ -592,7 +592,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 			if file.IsNotFoundErr(err) {
 				return nil, nil
 			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		return w, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Use CodeForError when we call filestore API. Additionally, use CodeForError to surface error codes returned from helper functions.  This will ensure that if the helper functions are changed in the future to return different error codes, those error codes will be surfaced. I also attempted to change some of the internal error codes to invalid argument, but will get feedback on whether that was correct. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
