### PR TITLE
Allow to add extra volume labels from command line option

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -122,6 +122,7 @@ type controllerServerConfig struct {
 	isRegional           bool
 	clusterName          string
 	features             *GCFSDriverFeatureOptions
+	extraVolumeLabels    map[string]string
 }
 
 func newControllerServer(config *controllerServerConfig) csi.ControllerServer {
@@ -273,6 +274,10 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		labels, err := extractLabels(param, s.config.driver.config.Name)
 		if err != nil {
 			return nil, err
+		}
+		// Append extra lables from the command line option
+		for k, v := range s.config.extraVolumeLabels {
+			labels[k] = v
 		}
 		newFiler.Labels = labels
 

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -54,21 +54,22 @@ const (
 )
 
 type GCFSDriverConfig struct {
-	Name             string          // Driver name
-	Version          string          // Driver version
-	NodeName         string          // Node name
-	RunController    bool            // Run CSI controller service
-	RunNode          bool            // Run CSI node service
-	Mounter          mount.Interface // Mount library
-	Cloud            *cloud.Cloud    // Cloud provider
-	MetadataService  metadataservice.Service
-	EnableMultishare bool
-	Reconciler       *MultishareReconciler
-	Metrics          *metrics.MetricsManager
-	EcfsDescription  string
-	IsRegional       bool
-	ClusterName      string
-	FeatureOptions   *GCFSDriverFeatureOptions
+	Name              string          // Driver name
+	Version           string          // Driver version
+	NodeName          string          // Node name
+	RunController     bool            // Run CSI controller service
+	RunNode           bool            // Run CSI node service
+	Mounter           mount.Interface // Mount library
+	Cloud             *cloud.Cloud    // Cloud provider
+	MetadataService   metadataservice.Service
+	EnableMultishare  bool
+	Reconciler        *MultishareReconciler
+	Metrics           *metrics.MetricsManager
+	EcfsDescription   string
+	IsRegional        bool
+	ClusterName       string
+	FeatureOptions    *GCFSDriverFeatureOptions
+	ExtraVolumeLabels map[string]string
 }
 
 type GCFSDriver struct {
@@ -181,17 +182,18 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 		}
 		// Configure controller server
 		driver.cs = newControllerServer(&controllerServerConfig{
-			driver:           driver,
-			fileService:      config.Cloud.File,
-			cloud:            config.Cloud,
-			volumeLocks:      util.NewVolumeLocks(),
-			enableMultishare: config.EnableMultishare,
-			reconciler:       config.Reconciler,
-			metricsManager:   config.Metrics,
-			ecfsDescription:  config.EcfsDescription,
-			isRegional:       config.IsRegional,
-			clusterName:      config.ClusterName,
-			features:         config.FeatureOptions,
+			driver:            driver,
+			fileService:       config.Cloud.File,
+			cloud:             config.Cloud,
+			volumeLocks:       util.NewVolumeLocks(),
+			enableMultishare:  config.EnableMultishare,
+			reconciler:        config.Reconciler,
+			metricsManager:    config.Metrics,
+			ecfsDescription:   config.EcfsDescription,
+			isRegional:        config.IsRegional,
+			clusterName:       config.ClusterName,
+			features:          config.FeatureOptions,
+			extraVolumeLabels: config.ExtraVolumeLabels,
 		})
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is basically a clone of the feature of GCP PD added with the https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/693.

The patch adds a new command line option `extra-labels` allowing users to automatically add custom labels to the disks provisioned by the driver. Main motivation is to be able to clearly denote cloud resource ownership and allow for automated resource management.

**Does this PR introduce a user-facing change?**:
```release-note
A new `extra-labels` command line option has been added. It can be used to attach extra labels to the provisioned volumes.
```
