### PR TITLE
Return InvalidArgument when can't create backup uri

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -519,7 +519,8 @@ func (manager *gcfsServiceManager) GetBackup(ctx context.Context, backupUri stri
 func (manager *gcfsServiceManager) CreateBackup(ctx context.Context, obj *ServiceInstance, backupName string, backupLocation string) (*filev1beta1.Backup, error) {
 	backupUri, region, err := CreateBackupURI(obj, backupName, backupLocation)
 	if err != nil {
-		return nil, err
+		klog.Errorf("Failed to create backup URI from given name %s and location %s, error: %v", backupName, backupLocation, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	backupSource := fmt.Sprintf("projects/%s/locations/%s/instances/%s", obj.Project, obj.Location, obj.Name)
@@ -721,7 +722,7 @@ func CodeForError(err error) *codes.Code {
 }
 
 // This function returns the backup URI, the region that was picked to be the backup resource location and error.
-func CreateBackupURI(obj *ServiceInstance, backupName, backupLocation string) (string, string, error) {
+func CreateBackupURI(obj *ServiceInstance, backupName string, backupLocation string) (string, string, error) {
 	region, err := deduceRegion(obj, backupLocation)
 	if err != nil {
 		return "", "", err

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -868,9 +868,11 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	}
 
 	// Check for existing snapshot
-	backupUri, _, err := file.CreateBackupURI(filer, req.Name, util.GetBackupLocation(req.GetParameters()))
+	backupLocation := util.GetBackupLocation(req.GetParameters())
+	backupUri, _, err := file.CreateBackupURI(filer, req.Name, backupLocation)
 	if err != nil {
-		return nil, err
+		klog.Errorf("Failed to create backup URI from given name %s and location %s, error: %v", req.Name, backupLocation, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	backupInfo, err := s.config.fileService.GetBackup(ctx, backupUri)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently we're getting SLO noise because invalid URIs are being treated as server errors
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Handle CreateBackupURI errors as InvalidArgument 
```
