### PR TITLE
Handle user error which is not wrapped as googleapi.Error

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -650,7 +650,8 @@ func isUserError(err error) *codes.Code {
 	// Upwrap the error
 	var apiErr *googleapi.Error
 	if !errors.As(err, &apiErr) {
-		return nil
+		// Fallback to check for expected error code in the error string
+		return containsUserErrStr(err)
 	}
 
 	userErrors := map[int]codes.Code{
@@ -661,6 +662,27 @@ func isUserError(err error) *codes.Code {
 	}
 	if code, ok := userErrors[apiErr.Code]; ok {
 		return &code
+	}
+	return nil
+}
+
+func containsUserErrStr(err error) *codes.Code {
+	if err == nil {
+		return nil
+	}
+
+	// Error string picked up from https://cloud.google.com/apis/design/errors#handling_errors
+	if strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		return util.ErrCodePtr(codes.PermissionDenied)
+	}
+	if strings.Contains(err.Error(), "RESOURCE_EXHAUSTED") {
+		return util.ErrCodePtr(codes.ResourceExhausted)
+	}
+	if strings.Contains(err.Error(), "INVALID_ARGUMENT") {
+		return util.ErrCodePtr(codes.InvalidArgument)
+	}
+	if strings.Contains(err.Error(), "NOT_FOUND") {
+		return util.ErrCodePtr(codes.NotFound)
 	}
 	return nil
 }

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -630,6 +630,26 @@ func TestIsUserError(t *testing.T) {
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusForbidden}),
 			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
 		},
+		{
+			name:            "RESOURCE_EXHAUSTED error",
+			err:             fmt.Errorf("got error: RESOURCE_EXHAUSTED: Operation rate exceeded"),
+			expectedErrCode: util.ErrCodePtr(codes.ResourceExhausted),
+		},
+		{
+			name:            "INVALID_ARGUMENT error",
+			err:             fmt.Errorf("got error: INVALID_ARGUMENT"),
+			expectedErrCode: util.ErrCodePtr(codes.InvalidArgument),
+		},
+		{
+			name:            "PERMISSION_DENIED error",
+			err:             fmt.Errorf("got error: PERMISSION_DENIED"),
+			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
+		},
+		{
+			name:            "NOT_FOUND error",
+			err:             fmt.Errorf("got error: NOT_FOUND"),
+			expectedErrCode: util.ErrCodePtr(codes.NotFound),
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Scale testing of Backups show that for some scenarios the error reported by the underlying file api implementation are not castable to googleapi.Error (errors.As(err, &apiErr) reports false). This causes [isUserError()](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/v1.5.3/pkg/cloud_provider/file/file.go#L647) to not handle these error cases. [CodeForError()](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/pkg/cloud_provider/file/file.go#L721) thus converts such errors to kInternal and cause SLO noise.  This PR tries to handle such scenarios by doing a fallback check for explicit error strings and handle them as user errors.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Here are some real examples for Backups scale test
Before fix CSI reports Internal GRPC error code
```
GRPC error: rpc error: code = Internal desc = WaitFor CreateBackup op projects/saikatroyc-stateful-joonix/locations/us-central1/operations/operation-1686031123822-5fd6fb637377c-e4b376b0-dff83952 for source instance projects/saikatroyc-stateful-joonix/locations/us-central1-c/instances/pvc-2854376c-71b0-4ba3-bae6-2a1de42ce477, backup uri: projects/saikatroyc-stateful-joonix/locations/us-central1/backups/snapshot-cd1aa67e-410b-4e32-8f41-4dea2c93a09a, operation failed: operation projects/saikatroyc-stateful-joonix/locations/us-central1/operations/operation-1686031123822-5fd6fb637377c-e4b376b0-dff83952 failed (8): RESOURCE_EXHAUSTED: Operation rate exceeded for resource "projects/saikatroyc-stateful-joonix/locations/us-central1-c/instances/pvc-2854376c-71b0-4ba3-bae6-2a1de42ce477"
```

After fix CSI reports ResourceExhausted GRPC error code
```
GRPC error: rpc error: code = ResourceExhausted desc = WaitFor CreateBackup op projects/saikatroyc-stateful-joonix/locations/us-central1/operations/operation-1686173187248-5fd90c9db129f-d218abeb-bc4ceac7 for source instance projects/saikatroyc-stateful-joonix/locations/us-central1-c/instances/pvc-23c8ac18-c50e-4eeb-a818-c6b5a15bbc24, backup uri: projects/saikatroyc-stateful-joonix/locations/us-central1/backups/snapshot-bd74e2c0-594d-4bda-95cc-ac26f55bedbc, operation failed: operation projects/saikatroyc-stateful-joonix/locations/us-central1/operations/operation-1686173187248-5fd90c9db129f-d218abeb-bc4ceac7 failed (8): RESOURCE_EXHAUSTED: Operation rate exceeded for resource "projects/saikatroyc-stateful-joonix/locations/us-central1-c/instances/pvc-23c8ac18-c50e-4eeb-a818-c6b5a15bbc24"
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Handle user error which is not wrapped as googleapi.Error
```
