### PR TITLE
Cherrypick #535 to release-1.5 

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -649,7 +649,8 @@ func isUserError(err error) *codes.Code {
 	// Upwrap the error
 	var apiErr *googleapi.Error
 	if !errors.As(err, &apiErr) {
-		return nil
+		// Fallback to check for expected error code in the error string
+		return containsUserErrStr(err)
 	}
 
 	userErrors := map[int]codes.Code{
@@ -660,6 +661,27 @@ func isUserError(err error) *codes.Code {
 	}
 	if code, ok := userErrors[apiErr.Code]; ok {
 		return &code
+	}
+	return nil
+}
+
+func containsUserErrStr(err error) *codes.Code {
+	if err == nil {
+		return nil
+	}
+
+	// Error string picked up from https://cloud.google.com/apis/design/errors#handling_errors
+	if strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		return util.ErrCodePtr(codes.PermissionDenied)
+	}
+	if strings.Contains(err.Error(), "RESOURCE_EXHAUSTED") {
+		return util.ErrCodePtr(codes.ResourceExhausted)
+	}
+	if strings.Contains(err.Error(), "INVALID_ARGUMENT") {
+		return util.ErrCodePtr(codes.InvalidArgument)
+	}
+	if strings.Contains(err.Error(), "NOT_FOUND") {
+		return util.ErrCodePtr(codes.NotFound)
 	}
 	return nil
 }

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -630,6 +630,26 @@ func TestIsUserError(t *testing.T) {
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusForbidden}),
 			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
 		},
+		{
+			name:            "RESOURCE_EXHAUSTED error",
+			err:             fmt.Errorf("got error: RESOURCE_EXHAUSTED: Operation rate exceeded"),
+			expectedErrCode: util.ErrCodePtr(codes.ResourceExhausted),
+		},
+		{
+			name:            "INVALID_ARGUMENT error",
+			err:             fmt.Errorf("got error: INVALID_ARGUMENT"),
+			expectedErrCode: util.ErrCodePtr(codes.InvalidArgument),
+		},
+		{
+			name:            "PERMISSION_DENIED error",
+			err:             fmt.Errorf("got error: PERMISSION_DENIED"),
+			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
+		},
+		{
+			name:            "NOT_FOUND error",
+			err:             fmt.Errorf("got error: NOT_FOUND"),
+			expectedErrCode: util.ErrCodePtr(codes.NotFound),
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Cherrypick #535 to release-1.5

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Handle user error which is not wrapped as googleapi.Error
```
