### PR TITLE
80 share support for stateful driver

### DIFF
--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -131,7 +131,7 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	maxSharesPerInstance, maxShareSizeSizeBytes, err := m.parseMaxVolumeSizeParam(req)
+	maxSharesPerInstance, maxShareSizeSizeBytes, err := m.parseMaxVolumeSizeParam(req.GetParameters())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -712,8 +712,7 @@ func generateInstanceDescFromEcfsDesc(desc string) string {
 	return d
 }
 
-func (m *MultishareController) parseMaxVolumeSizeParam(req *csi.CreateVolumeRequest) (int, int64, error) {
-	params := req.GetParameters()
+func (m *MultishareController) parseMaxVolumeSizeParam(params map[string]string) (int, int64, error) {
 	v, ok := params[paramMaxVolumeSize]
 	if !m.featureMaxSharePerInstance && ok {
 		return 0, 0, fmt.Errorf("configurable max shares per instance feature not enabled")

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -2035,7 +2035,7 @@ func TestParseMaxVolumeSizeParam(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m := initTestMultishareControllerWithFeatureOpts(t, tc.features)
-			sharePerInstance, maxShareCapacity, err := m.parseMaxVolumeSizeParam(tc.req)
+			sharePerInstance, maxShareCapacity, err := m.parseMaxVolumeSizeParam(tc.req.GetParameters())
 			if tc.expectError && err == nil {
 				t.Errorf("failed")
 			}

--- a/pkg/csi_driver/reconciler.go
+++ b/pkg/csi_driver/reconciler.go
@@ -505,6 +505,10 @@ func (recon *MultishareReconciler) generateNewMultishareInstance(instanceInfo *v
 		Description: generateInstanceDescFromEcfsDesc(recon.config.EcfsDescription),
 	}
 
+	if recon.controllerServer.config.multiShareController.featureMaxSharePerInstance {
+		instance.MaxShareCount = recon.parseMaxSharePerInstance(instanceInfo.Spec.Parameters)
+	}
+
 	// reserve ip range
 	var reservedIPRange string
 	if connectMode == privateServiceAccess {
@@ -591,7 +595,7 @@ func (recon *MultishareReconciler) fixTwoWayPointers(shareInfos map[string]*v1.S
 					var err error
 					if !ok {
 						klog.Errorf("Share %q is assigned to instance %q but instanceInfo does not exist. Trying to create one", shareName, shareInfo.Status.InstanceHandle)
-						actualAssigned, err = recon.generateInstanceInfo(shareInfo.Status.InstanceHandle, shareInfo.Spec.InstancePoolTag)
+						actualAssigned, err = recon.generateInstanceInfo(shareInfo.Status.InstanceHandle, shareInfo.Spec.InstancePoolTag, shareInfo.Spec.Parameters)
 						if err != nil {
 							klog.Errorf("Failed to create instanceInfo %q: %v", shareInfo.Status.InstanceHandle, err)
 							continue
@@ -649,7 +653,7 @@ func (recon *MultishareReconciler) assignSharesToEligibleOrNewInstances(shareInf
 					// if InstanceStatus is not empty but instance is no longer present, instance might have been manually deleted by user and can no longer be used
 					klog.Warningf("instanceInfo %s has non empty InstanceStatus but underlying instance does not exist. Skip assignment to that instance", instanceInfo.Name)
 				}
-				if instanceFitShare(instanceInfo, shareInfo) {
+				if recon.instanceFitShare(instanceInfo, shareInfo) {
 					instanceURI = util.InstanceInfoNameToInstanceURI(instanceInfo.Name)
 					instanceInfo, err = recon.assignShareToInstanceInfo(instanceInfo, shareInfo.Name)
 					if err != nil {
@@ -674,7 +678,7 @@ func (recon *MultishareReconciler) assignSharesToEligibleOrNewInstances(shareInf
 					Name:     util.NewMultishareInstancePrefix + string(uuid.NewUUID()),
 				})
 
-				instanceInfo, err := recon.generateInstanceInfo(instanceURI, shareInfo.Spec.InstancePoolTag)
+				instanceInfo, err := recon.generateInstanceInfo(instanceURI, shareInfo.Spec.InstancePoolTag, shareInfo.Spec.Parameters)
 				if err != nil {
 					klog.Errorf("Failed to create new instanceInfo %q: %v", instanceURI, err)
 					continue
@@ -732,7 +736,7 @@ func (recon *MultishareReconciler) deleteOrResizeInstances(instanceInfos map[str
 }
 
 // generateInstanceInfo generates and creates a new instanceInfo object based on instanceURI and storage class tag.
-func (recon *MultishareReconciler) generateInstanceInfo(instanceURI string, scTag string) (*v1.InstanceInfo, error) {
+func (recon *MultishareReconciler) generateInstanceInfo(instanceURI string, scTag string, shareParams map[string]string) (*v1.InstanceInfo, error) {
 	storageClass, err := recon.storageClassFromTag(scTag)
 	if err != nil {
 		return nil, err
@@ -748,6 +752,7 @@ func (recon *MultishareReconciler) generateInstanceInfo(instanceURI string, scTa
 		Spec: v1.InstanceInfoSpec{
 			CapacityBytes:    util.MinMultishareInstanceSizeBytes,
 			StorageClassName: storageClass.Name,
+			Parameters:       shareParams,
 		},
 	}
 	return recon.createInstanceInfo(context.TODO(), newInstanceInfo)
@@ -1257,7 +1262,7 @@ func (recon *MultishareReconciler) listMultishareResourceOps(ctx context.Context
 }
 
 // instanceFitShare returns true if shareInfo can be assigned to instanceInfo.
-func instanceFitShare(instanceInfo *v1.InstanceInfo, shareInfo *v1.ShareInfo) bool {
+func (recon *MultishareReconciler) instanceFitShare(instanceInfo *v1.InstanceInfo, shareInfo *v1.ShareInfo) bool {
 	// Instance needs to be:
 	// 1. not up for delete 2.of the same storage class and 3. has less than max number of shares assigned already.
 	if instanceInfo.DeletionTimestamp != nil ||
@@ -1265,7 +1270,9 @@ func instanceFitShare(instanceInfo *v1.InstanceInfo, shareInfo *v1.ShareInfo) bo
 		return false
 	}
 
-	if instanceInfo.Status != nil && len(instanceInfo.Status.ShareNames) >= util.MaxSharesPerInstance {
+	maxSharePerInstance := recon.parseMaxSharePerInstance(instanceInfo.Spec.Parameters)
+
+	if instanceInfo.Status != nil && len(instanceInfo.Status.ShareNames) >= maxSharePerInstance {
 		return false
 	}
 
@@ -1276,6 +1283,15 @@ func instanceFitShare(instanceInfo *v1.InstanceInfo, shareInfo *v1.ShareInfo) bo
 	}
 
 	return true
+}
+
+// parseMaxSharePerInstance assumes that params has valid parameter of max volume size and returns max share per instance
+func (recon *MultishareReconciler) parseMaxSharePerInstance(params map[string]string) int {
+	maxSharePerInstance, _, _ := recon.controllerServer.config.multiShareController.parseMaxVolumeSizeParam(params)
+	if maxSharePerInstance == 0 {
+		maxSharePerInstance = util.MaxSharesPerInstance
+	}
+	return maxSharePerInstance
 }
 
 // instanceEmpty returns true if instanceInfo.Status.ShareNames has zero entries.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
stateful driver now supports 80 share feature.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
