### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,7 +114,7 @@ func TestNodePublishVolume(t *testing.T) {
 	defaultPerm := os.FileMode(0750) + os.ModeDir
 
 	// Setup mount target path
-	base, err := ioutil.TempDir("", "node-publish-")
+	base, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -373,7 +372,7 @@ func testWindowsNodePublishVolume(t *testing.T) {
 	defaultOsString := goOs
 
 	// Setup mount target path
-	base, err := ioutil.TempDir("", "node-publish-")
+	base, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -471,7 +470,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	defaultPerm := os.FileMode(0750) + os.ModeDir
 
 	// Setup mount target path
-	base, err := ioutil.TempDir("", "node-publish-")
+	base, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -600,7 +599,7 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	ns := testEnv.ns
 
 	// Setup mount target path
-	tempDir, err := ioutil.TempDir("", "ngvs")
+	tempDir, err := os.MkdirTemp("", "ngvs")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -755,7 +754,7 @@ func TestConcurrentMounts(t *testing.T) {
 	// A channel of size 1 is sufficient, because the caller of runRequest() in below steps immediately blocks and retrieves the channel of empty struct from 'operationUnblocker' channel. The test steps are such that, atmost one function pushes items on the 'operationUnblocker' channel, to indicate that the function is blocked and waiting for a signal to proceed futher in the execution.
 	operationUnblocker := make(chan chan struct{}, 1)
 	ns := initBlockingTestNodeServer(t, operationUnblocker)
-	basePath, err := ioutil.TempDir("", "node-publish-")
+	basePath, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -886,7 +885,7 @@ func TestConcurrentMounts(t *testing.T) {
 }
 
 func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
-	basePath, err := ioutil.TempDir("", "node-publish-")
+	basePath, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}
@@ -1035,7 +1034,7 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 }
 
 func TestNodeUnstageVolumeUpdateLockInfo(t *testing.T) {
-	basePath, err := ioutil.TempDir("", "node-publish-")
+	basePath, err := os.MkdirTemp("", "node-publish-")
 	if err != nil {
 		t.Fatalf("failed to setup testdir: %v", err)
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -83,7 +83,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitHandler) {
 		http.Error(w, msg, http.StatusBadRequest)
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		msg := fmt.Sprintf("Request could not be decoded: %v", err)
 		klog.Error(msg)

--- a/test/k8s-integration/filter-junit.go
+++ b/test/k8s-integration/filter-junit.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -76,7 +75,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 	var mergeErrors []string
 	var filesToDelete []string
 	for _, dir := range sourceDirectories {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			klog.Errorf("Failed to read juint directory %s: %v", dir, err.Error())
 			mergeErrors = append(mergeErrors, err.Error())
@@ -88,7 +87,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 			}
 			fullFilename := filepath.Join(dir, file.Name())
 			filesToDelete = append(filesToDelete, fullFilename)
-			data, err := ioutil.ReadFile(fullFilename)
+			data, err := os.ReadFile(fullFilename)
 			if err != nil {
 				return err
 			}
@@ -121,7 +120,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 		return err
 	}
 
-	if err = ioutil.WriteFile(destination, data, 0644); err != nil {
+	if err = os.WriteFile(destination, data, 0644); err != nil {
 		return err
 	}
 

--- a/test/k8s-integration/utils.go
+++ b/test/k8s-integration/utils.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -30,7 +29,7 @@ func runCommand(action string, cmd *exec.Cmd) error {
 }
 
 func generateUniqueTmpDir() string {
-	dir, err := ioutil.TempDir("", "gcp-fs-driver-tmp")
+	dir, err := os.MkdirTemp("", "gcp-fs-driver-tmp")
 	if err != nil {
 		klog.Fatalf("Error creating temp dir: %v", err)
 	}

--- a/test/remote/archiver.go
+++ b/test/remote/archiver.go
@@ -18,7 +18,6 @@ package remote
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +27,7 @@ import (
 
 func CreateDriverArchive(archiveName, pkgPath, binPath string) (string, error) {
 	klog.V(2).Infof("Building archive...")
-	tarDir, err := ioutil.TempDir("", "driver-temp-archive")
+	tarDir, err := os.MkdirTemp("", "driver-temp-archive")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory %v", err)
 	}

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -19,7 +19,6 @@ package remote
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -277,7 +276,7 @@ func GetComputeClient(ctx context.Context, computeEndpoint string) (*compute.Ser
 }
 
 func generateMetadataWithPublicKey(pubKeyFile string) (*compute.Metadata, error) {
-	publicKeyByte, err := ioutil.ReadFile(pubKeyFile)
+	publicKeyByte, err := os.ReadFile(pubKeyFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
