### PR TITLE
high scale tier ip reservation support and remove cmek support check

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -309,6 +309,9 @@ func (s *controllerServer) reserveIPRange(ctx context.Context, filer *file.Servi
 	if filer.Tier == enterpriseTier {
 		ipRangeSize = util.IpRangeSizeEnterprise
 	}
+	if filer.Tier == highScaleTier {
+		ipRangeSize = util.IpRangeSizeHighScale
+	}
 	unreservedIPBlock, err := s.config.ipAllocator.GetUnreservedIPRange(cidr, ipRangeSize, cloudInstancesReservedIPRanges)
 	if err != nil {
 		return "", err
@@ -600,9 +603,6 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 		default:
 			return nil, fmt.Errorf("invalid parameter %q", k)
 		}
-	}
-	if kmsKeyName != "" && tier != enterpriseTier {
-		return nil, fmt.Errorf("KMS Key data encryption is only supported for enterprise tier instances")
 	}
 	return &file.ServiceInstance{
 		Project:  s.config.cloud.Project,

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -887,12 +887,29 @@ func TestGenerateNewFileInstance(t *testing.T) {
 			},
 		},
 		{
+			// not going to error here, instead, pushing the decision to the Filestore API
 			name: "non-enterprise tier, customer kms key",
 			params: map[string]string{
-				paramTier:                     "foo-tier",
-				ParamInstanceEncryptionKmsKey: "foo-key",
+				paramTier:                       basicHDDTier,
+				ParamInstanceEncryptionKmsKey:   "foo-key",
+				"csiProvisionerSecretName":      "foo-secret",
+				"csiProvisionerSecretNamespace": "foo-namespace",
 			},
-			expectErr: true,
+			instance: &file.ServiceInstance{
+				Project:  testProject,
+				Name:     testCSIVolume,
+				Location: testLocation,
+				Tier:     basicHDDTier,
+				Network: file.Network{
+					Name:        defaultNetwork,
+					ConnectMode: directPeering,
+				},
+				Volume: file.Volume{
+					Name:      newInstanceVolume,
+					SizeBytes: testBytes,
+				},
+				KmsKeyName: "foo-key",
+			},
 		},
 		{
 			name: "invalid params",

--- a/pkg/util/ip_def.go
+++ b/pkg/util/ip_def.go
@@ -22,4 +22,7 @@ const (
 
 	// the ipRangeSize for enterprise tier Filestore instances
 	IpRangeSizeEnterprise = 26
+
+	// the ipRangeSize for High Scale tier Filestore instances
+	IpRangeSizeHighScale = 24
 )

--- a/pkg/util/ip_reservation_test.go
+++ b/pkg/util/ip_reservation_test.go
@@ -127,6 +127,15 @@ func TestGetUnReservedIPRange(t *testing.T) {
 			errorExpected:                 false,
 		},
 		{
+			name:                          "0 Pending, 0 Used high scale",
+			cidr:                          "192.168.92.0/22",
+			ipRangeSize:                   IpRangeSizeHighScale,
+			pendingIPRanges:               make(map[string]bool),
+			cloudProviderReservedIPRanges: make(map[string]bool),
+			expected:                      "192.168.92.0/24",
+			errorExpected:                 false,
+		},
+		{
 			name:            "0 Pending, 1 /29 Used",
 			cidr:            "192.168.92.0/27",
 			ipRangeSize:     IpRangeSize,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
code change required to support high scale tier

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

`Warning  ProvisioningFailed    3s (x5 over 19s)      filestore.csi.storage.gke.io_gke-test-recon-default-pool-9053d3d5-11rf_0a08c303-a5d9-49c5-834e-8a3867a44617  failed to provision volume with StorageClass "csi-filestore": rpc error: code = InvalidArgument desc = googleapi: Error 400: tier BASIC_HDD does not support KMS encryption., badRequest`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CMEK support now won't be checked in the CSI driver, trying to create basic or premium tier instances with cmek will result in invalid argument error from the Filestore API.

high scale tier instance creation with IP reservation is now supported
```
