### PR TITLE
Automated cherry pick of #535: Handle user error which is not wrapped as googleapi.Err

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -646,7 +646,8 @@ func IsUserError(err error) *codes.Code {
 	// Upwrap the error
 	var apiErr *googleapi.Error
 	if !errors.As(err, &apiErr) {
-		return nil
+		// Fallback to check for expected error code in the error string
+		return containsUserErrStr(err)
 	}
 
 	userErrors := map[int]codes.Code{
@@ -661,7 +662,28 @@ func IsUserError(err error) *codes.Code {
 	return nil
 }
 
-// IsContextError returns a pointer to the grpc error code DeadlineExceeded
+func containsUserErrStr(err error) *codes.Code {
+	if err == nil {
+		return nil
+	}
+
+	// Error string picked up from https://cloud.google.com/apis/design/errors#handling_errors
+	if strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		return util.ErrCodePtr(codes.PermissionDenied)
+	}
+	if strings.Contains(err.Error(), "RESOURCE_EXHAUSTED") {
+		return util.ErrCodePtr(codes.ResourceExhausted)
+	}
+	if strings.Contains(err.Error(), "INVALID_ARGUMENT") {
+		return util.ErrCodePtr(codes.InvalidArgument)
+	}
+	if strings.Contains(err.Error(), "NOT_FOUND") {
+		return util.ErrCodePtr(codes.NotFound)
+	}
+	return nil
+}
+
+// isContextError returns a pointer to the grpc error code DeadlineExceeded
 // if the passed in error contains the "context deadline exceeded" string and returns
 // the grpc error code Canceled if the error contains the "context canceled" string.
 func IsContextError(err error) *codes.Code {

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -624,6 +624,26 @@ func TestIsUserError(t *testing.T) {
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusForbidden}),
 			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
 		},
+		{
+			name:            "RESOURCE_EXHAUSTED error",
+			err:             fmt.Errorf("got error: RESOURCE_EXHAUSTED: Operation rate exceeded"),
+			expectedErrCode: util.ErrCodePtr(codes.ResourceExhausted),
+		},
+		{
+			name:            "INVALID_ARGUMENT error",
+			err:             fmt.Errorf("got error: INVALID_ARGUMENT"),
+			expectedErrCode: util.ErrCodePtr(codes.InvalidArgument),
+		},
+		{
+			name:            "PERMISSION_DENIED error",
+			err:             fmt.Errorf("got error: PERMISSION_DENIED"),
+			expectedErrCode: util.ErrCodePtr(codes.PermissionDenied),
+		},
+		{
+			name:            "NOT_FOUND error",
+			err:             fmt.Errorf("got error: NOT_FOUND"),
+			expectedErrCode: util.ErrCodePtr(codes.NotFound),
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Cherry pick of #535 on release-1.4.

#535: Handle user error which is not wrapped as googleapi.Err

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```