### PR TITLE
Multishare Create Backup

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	cloud "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/file"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
@@ -87,6 +89,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 		s              *file.ServiceInstance
 		backupName     string
 		backupLocation string
+		SourceVolumeId string
 	}
 	backupName := "mybackup"
 	instanceName := "myinstance"
@@ -153,6 +156,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 				},
 				backupName:     backupName,
 				backupLocation: testRegion,
+				SourceVolumeId: modeInstance + "/" + testZone + "/" + instanceName + "/" + shareName,
 			},
 		},
 		{
@@ -199,6 +203,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 				},
 				backupName:     backupName,
 				backupLocation: testRegion,
+				SourceVolumeId: modeInstance + "/" + testZone + "/" + instanceName + "/" + shareName,
 			},
 		},
 		{
@@ -245,6 +250,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 				},
 				backupName:     backupName,
 				backupLocation: testRegion,
+				SourceVolumeId: modeInstance + "/" + testRegion + "/" + instanceName + "/" + shareName,
 			},
 		},
 	}
@@ -253,7 +259,18 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 		cs := initTestController(t).(*controllerServer)
 
 		//Create initial backup
-		cs.config.fileService.CreateBackup(context.TODO(), test.initialBackup.s, test.initialBackup.backupName, test.initialBackup.backupLocation)
+		backupInfo := &file.BackupInfo{
+			Project:            test.initialBackup.s.Project,
+			Location:           test.initialBackup.backupLocation,
+			SourceInstanceName: test.initialBackup.s.Name,
+			SourceShare:        test.initialBackup.s.Volume.Name,
+			Name:               test.initialBackup.backupName,
+			SourceVolumeId:     test.initialBackup.SourceVolumeId,
+			BackupURI:          test.resp.Volume.ContentSource.GetSnapshot().SnapshotId,
+			Labels:             make(map[string]string),
+		}
+
+		cs.config.fileService.CreateBackup(context.TODO(), backupInfo)
 
 		// Restore from backup
 		resp, err := cs.CreateVolume(context.TODO(), test.req)
@@ -268,6 +285,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 		}
 	}
 }
+
 func TestCreateVolume(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -1252,10 +1270,9 @@ func ValidateExpectedError(t *testing.T, errResp <-chan error, operationUnblocke
 }
 
 func TestCreateSnapshot(t *testing.T) {
-	type BackupInfo struct {
-		s              *file.ServiceInstance
-		backupName     string
-		backupLocation string
+	type BackupTestInfo struct {
+		backup *file.BackupInfo
+		state  string
 	}
 	backupName := "mybackup"
 	project := "test-project"
@@ -1263,46 +1280,39 @@ func TestCreateSnapshot(t *testing.T) {
 	region := "us-central1"
 	instanceName := "myinstance"
 	shareName := "myshare"
+	defaultBackupUri := fmt.Sprintf("projects/%s/locations/%s/backups/%s", project, region, backupName)
 	cases := []struct {
 		name          string
 		req           *csi.CreateSnapshotRequest
-		initialBackup *BackupInfo
+		resp          *csi.CreateSnapshotResponse
+		initialBackup *BackupTestInfo
 		expectErr     bool
 	}{
 		// Failure test cases
 		{
-			name: "Create snapshot request for multishare backed volumes",
-			req: &csi.CreateSnapshotRequest{
-				SourceVolumeId: "modeMultishare/mysc/test-project/location/myinstance/myshare",
-			},
-			expectErr: true,
-		},
-		{
 			name: "Existing backup found, with different volume Id (source zonal filestore instance), error expected",
 			req: &csi.CreateSnapshotRequest{
-				SourceVolumeId: "modeInstance/us-central1-c/myinstance1/myshare",
+				SourceVolumeId: modeInstance + "/" + zone + "/" + "myinstance1" + "/" + shareName,
 				Name:           backupName,
 				Parameters: map[string]string{
 					util.VolumeSnapshotTypeKey: "backup",
 				},
 			},
-			initialBackup: &BackupInfo{
-				s: &file.ServiceInstance{
-					Project:  project,
-					Location: zone,
-					Name:     instanceName,
-					Volume: file.Volume{
-						Name: shareName,
-					},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     modeInstance + "/" + zone + "/" + instanceName + "/" + shareName,
 				},
-				backupName:     backupName,
-				backupLocation: region,
 			},
 			expectErr: true,
 		},
-		// Success test cases
 		{
-			name: "Existing backup found, with same source volume Id (blank backup location)",
+			name: "Existing backup found in state CREATING",
 			req: &csi.CreateSnapshotRequest{
 				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
 				Name:           backupName,
@@ -1310,18 +1320,78 @@ func TestCreateSnapshot(t *testing.T) {
 					util.VolumeSnapshotTypeKey: "backup",
 				},
 			},
-			initialBackup: &BackupInfo{
-				s: &file.ServiceInstance{
-					Project:  project,
-					Location: region,
-					Name:     instanceName,
-					Volume: file.Volume{
-						Name: shareName,
-					},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1/myinstance/myshare",
 				},
-				backupName:     backupName,
-				backupLocation: "",
+				state: "CREATING",
 			},
+			expectErr: true,
+		},
+		// Success test cases
+		{
+			name: "No backup found",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+				},
+			},
+			resp: &csi.CreateSnapshotResponse{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      1 * util.Tb,
+					SnapshotId:     defaultBackupUri,
+					SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+					ReadyToUse:     true,
+				},
+			},
+			initialBackup: nil,
+		},
+		{
+			name: "No backup found, zonal source",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+				},
+			},
+			resp: &csi.CreateSnapshotResponse{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      1 * util.Tb,
+					SnapshotId:     defaultBackupUri,
+					SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+					ReadyToUse:     true,
+				},
+			},
+			initialBackup: nil,
+		},
+		{
+			name: "No backup found, cross regional snapshot",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey:     "backup",
+					util.VolumeSnapshotLocationKey: "us-west1",
+				},
+			},
+			resp: &csi.CreateSnapshotResponse{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      1 * util.Tb,
+					SnapshotId:     fmt.Sprintf("projects/%s/locations/%s/backups/%s", project, "us-west1", backupName),
+					SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+					ReadyToUse:     true,
+				},
+			},
+			initialBackup: nil,
 		},
 		{
 			name: "Existing backup found, with same source volume Id (source regional filestore instance)",
@@ -1332,17 +1402,16 @@ func TestCreateSnapshot(t *testing.T) {
 					util.VolumeSnapshotTypeKey: "backup",
 				},
 			},
-			initialBackup: &BackupInfo{
-				s: &file.ServiceInstance{
-					Project:  project,
-					Location: region,
-					Name:     instanceName,
-					Volume: file.Volume{
-						Name: shareName,
-					},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1/myinstance/myshare",
 				},
-				backupName:     backupName,
-				backupLocation: region,
 			},
 		},
 		{
@@ -1354,17 +1423,16 @@ func TestCreateSnapshot(t *testing.T) {
 					util.VolumeSnapshotTypeKey: "backup",
 				},
 			},
-			initialBackup: &BackupInfo{
-				s: &file.ServiceInstance{
-					Project:  project,
-					Location: zone,
-					Name:     instanceName,
-					Volume: file.Volume{
-						Name: shareName,
-					},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1-c/myinstance/myshare",
 				},
-				backupName:     backupName,
-				backupLocation: region,
 			},
 		},
 	}
@@ -1386,14 +1454,46 @@ func TestCreateSnapshot(t *testing.T) {
 		})
 
 		if test.initialBackup != nil {
-			fileService.CreateBackup(context.TODO(), test.initialBackup.s, test.initialBackup.backupName, test.initialBackup.backupLocation)
+			existingBackup, err := fileService.CreateBackup(context.TODO(), test.initialBackup.backup)
+			if err != nil {
+				t.Errorf("test %q failed to create snapshot: %v", test.name, err)
+			}
+			if test.initialBackup.state != "" {
+				klog.Infof("existingBackup looks like: %+v", existingBackup)
+
+				existingBackup.State = test.initialBackup.state
+			}
 		}
-		_, err = cs.CreateSnapshot(context.TODO(), test.req)
+		resp, err := cs.CreateSnapshot(context.TODO(), test.req)
 		if !test.expectErr && err != nil {
 			t.Errorf("test %q failed: %v", test.name, err)
 		}
 		if test.expectErr && err == nil {
 			t.Errorf("test %q failed; got success", test.name)
+		}
+		if test.resp != nil {
+			if resp.Snapshot.SizeBytes != test.resp.Snapshot.SizeBytes {
+				t.Errorf("test %q failed, %v, mismatch, got %v, want %v", test.name, "SizeBytes", resp.Snapshot.SizeBytes, test.resp.Snapshot.SizeBytes)
+			}
+			if resp.Snapshot.SnapshotId != test.resp.Snapshot.SnapshotId {
+				t.Errorf("test %q failed, %v, mismatch, got %v, want %v", test.name, "SnapshotId", resp.Snapshot.SnapshotId, test.resp.Snapshot.SnapshotId)
+			}
+			if resp.Snapshot.SourceVolumeId != test.resp.Snapshot.SourceVolumeId {
+				t.Errorf("test %q failed, %v, mismatch, got %v, want %v", test.name, "SourceVolumeId", resp.Snapshot.SourceVolumeId, test.resp.Snapshot.SourceVolumeId)
+			}
+			if resp.Snapshot.ReadyToUse != test.resp.Snapshot.ReadyToUse {
+				t.Errorf("test %q failed, %v, mismatch, got %v, want %v", test.name, "ReadyToUse", resp.Snapshot.ReadyToUse, test.resp.Snapshot.ReadyToUse)
+			}
+		}
+
+		if !test.expectErr && test.initialBackup == nil {
+			backup, _ := fileService.GetBackup(context.TODO(), resp.Snapshot.SnapshotId)
+			if backup.Backup.Labels[tagKeyCreatedBy] != "test-driver" {
+				t.Errorf("labels check for %v failed on test %q, got %v, want %v", tagKeyCreatedBy, test.name, backup.Backup.Labels[tagKeyCreatedBy], "test-driver")
+			}
+			if backup.Backup.Labels[tagKeySnapshotName] != test.req.Name {
+				t.Errorf("labels check for %v failed on test %q, got %v, want %v", tagKeySnapshotName, test.name, backup.Backup.Labels[tagKeySnapshotName], test.req.Name)
+			}
 		}
 	}
 }
@@ -1402,101 +1502,70 @@ func TestCreateBackupURI(t *testing.T) {
 	backupName := "mybackup"
 	project := "test-project"
 	region := "us-central1"
-	instanceName := "myinstance"
-	shareName := "myshare"
 	cases := []struct {
-		name           string
-		backupName     string
-		backupLocation string
-		instance       *file.ServiceInstance
-		expectedURL    string
-		expectedRegion string
-		expectErr      bool
+		name            string
+		backupName      string
+		backupLocation  string
+		serviceLocation string
+		project         string
+		expectedURL     string
+		expectedRegion  string
+		expectErr       bool
 	}{
 		//Failure cases
 		{
-			name:           "backupLocation is zone instead of region. Expect error",
-			backupName:     backupName,
-			backupLocation: "us-west1-c",
-			instance: &file.ServiceInstance{
-				Project:  project,
-				Location: "us-west1-c",
-				Name:     instanceName,
-				Volume: file.Volume{
-					Name: shareName,
-				},
-			},
-			expectedURL:    "",
-			expectedRegion: "",
-			expectErr:      true,
+			name:            "backupLocation is zone instead of region. Expect error",
+			backupName:      backupName,
+			backupLocation:  "us-west1-c",
+			serviceLocation: "us-west1-c",
+			project:         project,
+			expectedURL:     "",
+			expectedRegion:  "",
+			expectErr:       true,
 		},
 		{
-			name:           "Invalid location in ServiceInstance. Expect error",
-			backupName:     backupName,
-			backupLocation: "",
-			instance: &file.ServiceInstance{
-				Project:  project,
-				Location: "us-west1-c-b-d",
-				Name:     instanceName,
-				Volume: file.Volume{
-					Name: shareName,
-				},
-			},
-			expectedURL:    "",
-			expectedRegion: "",
-			expectErr:      true,
+			name:            "Invalid location in ServiceInstance. Expect error",
+			backupName:      backupName,
+			backupLocation:  "",
+			serviceLocation: "us-west1-c-b-d",
+			project:         project,
+			expectedURL:     "",
+			expectedRegion:  "",
+			expectErr:       true,
 		},
 		{
-			name:           "Region is not provided. ServiceInstance is regional.",
-			backupName:     backupName,
-			backupLocation: "",
-			instance: &file.ServiceInstance{
-				Project:  project,
-				Location: "us-west1",
-				Name:     instanceName,
-				Volume: file.Volume{
-					Name: shareName,
-				},
-			},
-			expectedURL:    "projects/test-project/locations/us-west1/backups/mybackup",
-			expectedRegion: "us-west1",
-			expectErr:      false,
+			name:            "Region is not provided. ServiceInstance is regional.",
+			backupName:      backupName,
+			backupLocation:  "",
+			serviceLocation: "us-west1",
+			project:         project,
+			expectedURL:     "projects/test-project/locations/us-west1/backups/mybackup",
+			expectedRegion:  "us-west1",
+			expectErr:       false,
 		},
 		{
-			name:           "Region is not provided. ServiceInstance is zonal.",
-			backupName:     backupName,
-			backupLocation: "",
-			instance: &file.ServiceInstance{
-				Project:  project,
-				Location: "us-west1-c",
-				Name:     instanceName,
-				Volume: file.Volume{
-					Name: shareName,
-				},
-			},
-			expectedURL:    "projects/test-project/locations/us-west1/backups/mybackup",
-			expectedRegion: "us-west1",
-			expectErr:      false,
+			name:            "Region is not provided. ServiceInstance is zonal.",
+			backupName:      backupName,
+			backupLocation:  "",
+			serviceLocation: "us-west1-c",
+			project:         project,
+			expectedURL:     "projects/test-project/locations/us-west1/backups/mybackup",
+			expectedRegion:  "us-west1",
+			expectErr:       false,
 		},
 		{
-			name:           "Region is provided and is different from ServiceInstance. Take region",
-			backupName:     backupName,
-			backupLocation: region,
-			instance: &file.ServiceInstance{
-				Project:  project,
-				Location: "us-west1-c",
-				Name:     instanceName,
-				Volume: file.Volume{
-					Name: shareName,
-				},
-			},
-			expectedURL:    "projects/test-project/locations/us-central1/backups/mybackup",
-			expectedRegion: "us-central1",
-			expectErr:      false,
+			name:            "Region is provided and is different from ServiceInstance. Take region",
+			backupName:      backupName,
+			backupLocation:  region,
+			serviceLocation: "us-west1-c",
+			project:         project,
+			expectedURL:     "projects/test-project/locations/us-central1/backups/mybackup",
+			expectedRegion:  "us-central1",
+			expectErr:       false,
 		},
 	}
 	for _, test := range cases {
-		returnedURL, returnedRegion, err := file.CreateBackupURI(test.instance, test.backupName, test.backupLocation)
+		returnedURL, returnedRegion, err := file.CreateBackupURI(test.serviceLocation, test.project, test.backupName, test.backupLocation)
 		if !test.expectErr && err != nil {
 			t.Errorf("test %q failed: %v", test.name, err)
 		}

--- a/pkg/util/multishare_defs.go
+++ b/pkg/util/multishare_defs.go
@@ -22,6 +22,7 @@ const (
 	InstanceURISplitLen        = 6
 	ShareURISplitLen           = 8
 	MultishareCSIVolIdSplitLen = 6
+	SourceVolumeIdSplitLen     = 4
 
 	MinMultishareInstanceSizeBytes    int64 = 1 * Tb
 	MaxMultishareInstanceSizeBytes    int64 = 10 * Tb

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -50,7 +50,9 @@ const (
 	snapshotTotalElements = 6
 
 	// number of elements in backup Volume sources e.g. projects/{project name}/locations/{zone}/instances/{name}
-	volumeTotalElements = 6
+	singleShareVolumeTotalElements = 6
+	// number of elements in backup Volume sources e.g. projects/{project name}/locations/{zone}/instances/{name}/shares/{share}'
+	multiShareVolumeTotalElements = 8
 
 	ManagedFilestoreCSINamespace = "gke-managed-filestorecsi"
 )
@@ -203,12 +205,18 @@ func GetBackupLocation(params map[string]string) string {
 	return location
 }
 
-func BackupVolumeSourceToCSIVolumeHandle(sourceInstance, sourceShare string) (string, error) {
+func BackupVolumeSourceToCSIVolumeHandle(mode, sourceInstance, sourceShare string) (string, error) {
 	splitId := strings.Split(sourceInstance, "/")
-	if len(splitId) != volumeTotalElements {
-		return "", fmt.Errorf("Failed to get id components. Expected 'projects/{project}/location/{zone}/instances/{name}'. Got: %s", sourceInstance)
+	if mode == "modeInstance" {
+		if len(splitId) != singleShareVolumeTotalElements {
+			return "", fmt.Errorf("Failed to get id components. Expected 'projects/{project}/location/{zone}/instances/{name}'. Got: %s", sourceInstance)
+		}
+	} else {
+		if len(splitId) != multiShareVolumeTotalElements {
+			return "", fmt.Errorf("Failed to get id components. Expected 'projects/{project}/location/{zone}/instances/{name}/shares/{share}'. Got: %s", sourceInstance)
+		}
 	}
-	return fmt.Sprintf("modeInstance/%s/%s/%s", splitId[3], splitId[5], sourceShare), nil
+	return fmt.Sprintf("%s/%s/%s/%s", mode, splitId[3], splitId[5], sourceShare), nil
 }
 
 // Multishare util functions.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This allows us to create multishare backups 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Main Changes:

- Rename the current `BackupInfo` struct to `Backup`.
- Introduce new `BackupInfo` struct that contains all of the information needed to create a new backup.
- Refactor Singleshare CreateBackup to use the new `backupinfo` struct instead of overloading the ServiceInstance. 
- Refactor backup related helper methods to no longer take a `ServiceInstance` object. 
- Add Multishare CreateBackup
- Add labels to multishare createbackup
- Update unit tests to no longer use service instance. The `initialBackup` field was being used incorrectly/unintuitively. Clarify what each test is testing.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Implement creating multishare backup
```
