### PR TITLE
[release-1.3]Update Go version to 1.20.7 to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ARG BUILDPLATFORM
 
 # Build driver go binary
-FROM --platform=$BUILDPLATFORM golang:1.20.6 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.20.6 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7 as builder
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Updates go version to 1.20.7 to fix CVEs CVE-2023-29409 CVE-2023-39533. Related PRs #590 #592 #593 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533
```