### PR TITLE
Update changelog for release v1.6.2, v1.5.8, v1.3.18

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -1,6 +1,14 @@
 **Attention:**
 1.3.3 is not a recommended version to use because of known issues which can cause failures in volume provisioning with ip reservation. Users are recommended to skip 1.3.3 and directly use 1.3.4
 
+# v1.3.18 - Changelog since v1.3.17
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#594](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/594), [@Sneha-at](https://github.com/Sneha-at))
+
 # v1.3.17 - Changelog since v1.3.16
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -1,6 +1,15 @@
 **Attention:**
 1.3.3 is not a recommended version to use because of known issues which can cause failures in volume provisioning with ip reservation. Users are recommended to skip 1.3.3 and directly use 1.3.4
 
+# v1.3.17 - Changelog since v1.3.16
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Fix backup source comparison logic for single share instances ([#572](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/572), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#578](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/578), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.3.16 - Changelog since v1.3.15
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -1,3 +1,11 @@
+# v1.4.7 - Changelog since v1.4.6
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Improve error code logging ([#574](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/574), [@judemars](https://github.com/judemars))
+
 # v1.4.6 - Changelog since v1.4.5
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,3 +1,15 @@
+# v1.5.8 - Changelog since v1.5.7
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#593](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/593), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- CMEK support now won't be checked in the CSI driver, trying to create basic or premium tier instances with cmek will result in invalid argument error from the Filestore API. high scale tier instance creation with IP reservation is now supported ([#589](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/589), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.5.7 - Changelog since v1.5.6
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,3 +1,17 @@
+# v1.5.7 - Changelog since v1.5.6
+
+## Changes by Kind
+
+### Feature
+
+- Promote CRD to v1 ([#542](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/542), [@leiyiz](https://github.com/leiyiz))
+- 80 share support for stateful driver ([#559](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/559), [@leiyiz](https://github.com/leiyiz))
+
+### Bug or Regression
+
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#577](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/577), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+- Improve error code classification from Filestore API ([#562](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/562), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.5.6 - Changelog since v1.5.5
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -1,3 +1,11 @@
+# v1.6.1 - Changelog since v1.6.0
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#576](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/576), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.6.0 - Changelog since v1.5.6
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -1,3 +1,15 @@
+# v1.6.2 - Changelog since v1.6.1
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#592](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/592), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- Now supports tier "zonal" with large band. small band is actively blocked ([#588](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/588), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.6.1 - Changelog since v1.6.0
 
 ## Changes by Kind


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Update release specific changelog for recent gcp-filestore-csi-driver releases

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
