### PR TITLE
Block multishare backups

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -869,15 +869,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 		return nil, status.Error(codes.InvalidArgument, "CreateSnapshot source volume ID must be provided")
 	}
 	if isMultishareVolId(volumeID) {
-		if s.config.multiShareController == nil {
-			return nil, status.Error(codes.InvalidArgument, "multishare controller not enabled")
-		}
-		start := time.Now()
-		response, err := s.config.multiShareController.CreateSnapshot(ctx, req)
-		duration := time.Since(start)
-		s.config.metricsManager.RecordOperationMetrics(err, methodCreateSnapshot, modeMultishare, duration)
-		klog.Infof("CreateSnapshot response %+v error %v, for request %+v", response, err, req)
-		return response, err
+		return nil, status.Error(codes.InvalidArgument, "CreateSnapshot is not supported for multishare backed volumes")
 	}
 
 	if acquired := s.config.volumeLocks.TryAcquire(volumeID); !acquired {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -1524,17 +1524,6 @@ func TestDeleteSnapshot(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "Create mutltishare snapshot and delete it",
-			createReq: &csi.CreateSnapshotRequest{
-				SourceVolumeId: fmt.Sprintf("modeMultishare/%s/%s/%s", zone, instanceName, shareName),
-				Name:           backupName,
-			},
-			deleteReq: &csi.DeleteSnapshotRequest{
-				SnapshotId: fmt.Sprintf("projects/%s/locations/%s/backups/%s", project, region, backupName),
-			},
-			expectErr: false,
-		},
-		{
 			name: "Backup is already in state DELETING. Expect error",
 			createReq: &csi.CreateSnapshotRequest{
 				SourceVolumeId: fmt.Sprintf("modeInstance/%s/%s/%s", zone, instanceName, shareName),

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -124,9 +124,10 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 	if err := m.driver.validateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	sourceSnapshotId, err := m.checkVolumeContentSource(ctx, req)
-	if err != nil {
-		return nil, err
+
+	sourceSnapshotId := ""
+	if req.GetVolumeContentSource() != nil {
+		return nil, status.Error(codes.InvalidArgument, "Multishare backed volumes do not support volume content source")
 	}
 
 	instanceScPrefix, err := getInstanceSCLabel(req)

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -832,6 +832,30 @@ func TestMultishareCreateVolume(t *testing.T) {
 			errorExpected: true,
 		},
 		{
+			name: "create volume called with volume content source",
+			req: &csi.CreateVolumeRequest{
+				Name: testVolName,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 100 * util.Gb,
+				},
+				Parameters: map[string]string{
+					ParamMultishareInstanceScLabel: testInstanceScPrefix,
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				VolumeContentSource: &csi.VolumeContentSource{},
+			},
+			errorExpected: true,
+		},
+		{
 			name: "create volume called with volume size < 100G in limit bytes",
 			req: &csi.CreateVolumeRequest{
 				Name: testVolName,
@@ -1175,6 +1199,7 @@ func TestMultishareCreateVolume(t *testing.T) {
 	}
 }
 
+/*
 func TestMultishareCreateVolumeFromBackup(t *testing.T) {
 	type BackupTestInfo struct {
 		backup *file.BackupInfo
@@ -1589,6 +1614,7 @@ func TestMultishareCreateVolumeFromBackup(t *testing.T) {
 		})
 	}
 }
+*/
 
 func TestMultishareDeleteVolume(t *testing.T) {
 	testVolName := "pvc-" + string(uuid.NewUUID())
@@ -2441,6 +2467,7 @@ func TestParseMaxVolumeSizeParam(t *testing.T) {
 	}
 }
 
+/*
 func TestCreateMultishareSnapshot(t *testing.T) {
 
 	type BackupTestInfo struct {
@@ -2652,3 +2679,4 @@ func TestCreateMultishareSnapshot(t *testing.T) {
 
 	}
 }
+*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Temporarily block multishare backups. Can be reverted once we're ready to launch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Temporarily block multishare backups
```
