### PR TITLE
[release-1.4] Automated cherry pick of #523: Use CodeForError when we call filestore API, as well as when

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -623,8 +623,8 @@ func getInstanceNameFromURI(uri string) (project, location, name string, err err
 }
 
 func IsNotFoundErr(err error) bool {
-	apiErr, ok := err.(*googleapi.Error)
-	if !ok {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
 		return false
 	}
 
@@ -716,7 +716,7 @@ func existingErrorCode(err error) *codes.Code {
 	return nil
 }
 
-// CodeForError returns a pointer to the grpc error code that maps to the http
+// codeForError returns a pointer to the grpc error code that maps to the http
 // error code for the passed in user googleapi error or context error. Returns
 // codes.Internal if the given error is not a googleapi error caused by the user.
 // The following http error codes are considered user errors:
@@ -727,7 +727,10 @@ func existingErrorCode(err error) *codes.Code {
 // The following errors are considered context errors:
 // (1) "context deadline exceeded", returns grpc DeadlineExceeded,
 // (2) "context canceled", returns grpc Canceled
-func CodeForError(err error) *codes.Code {
+func codeForError(err error) *codes.Code {
+	if err == nil {
+		return nil
+	}
 	if errCode := existingErrorCode(err); errCode != nil {
 		return errCode
 	}
@@ -739,6 +742,15 @@ func CodeForError(err error) *codes.Code {
 	}
 
 	return util.ErrCodePtr(codes.Internal)
+}
+
+// Status error returns the error as a grpc status error, and
+// sets the grpc error code according to CodeForError.
+func StatusError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return status.Error(*codeForError(err), err.Error())
 }
 
 // This function returns the backup URI, the region that was picked to be the backup resource location and error.

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -581,15 +581,46 @@ func TestCodeForError(t *testing.T) {
 			err:             status.Error(codes.Aborted, "aborted error"),
 			expectedErrCode: util.ErrCodePtr(codes.Aborted),
 		},
+		{
+			name:            "nil error",
+			err:             nil,
+			expectedErrCode: nil,
+		},
 	}
 
 	for _, test := range cases {
-		errCode := CodeForError(test.err)
+		errCode := codeForError(test.err)
 		if (test.expectedErrCode == nil) != (errCode == nil) {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
 		}
 		if test.expectedErrCode != nil && *errCode != *test.expectedErrCode {
 			t.Errorf("test %v failed: got %v, expected %v", test.name, errCode, test.expectedErrCode)
+		}
+	}
+}
+
+func TestStatusError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		expectedErr error
+	}{
+		{
+			name:        "404 googleapi error",
+			err:         &googleapi.Error{Code: http.StatusNotFound},
+			expectedErr: status.Error(codes.NotFound, ""),
+		},
+		{
+			name:        "nil error",
+			err:         nil,
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range cases {
+		err := StatusError(test.err)
+		if (test.expectedErr == nil) != (err == nil) {
+			t.Errorf("test %v failed: got %v, expected %v", test.name, err, test.expectedErr)
 		}
 	}
 }

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -188,7 +188,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			_, err = s.config.fileService.GetBackup(ctx, id)
 			if err != nil {
 				klog.Errorf("Failed to get volume %v source snapshot %v: %v", name, id, err.Error())
-				return nil, status.Error(*file.CodeForError(err), err.Error())
+				return nil, file.StatusError(err)
 			}
 			sourceSnapshotId = id
 		}
@@ -198,7 +198,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 	filer, err := s.config.fileService.GetInstance(ctx, newFiler)
 	// No error is returned if the instance is not found during CreateVolume.
 	if err != nil && !file.IsNotFoundErr(err) {
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	if filer != nil {
@@ -237,7 +237,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			// In case of abort, the CIDR IP is released and available for reservation
 			defer s.config.ipAllocator.ReleaseIPRange(reservedIPRange)
 			if err != nil {
-				return nil, err
+				return nil, file.StatusError(err)
 			}
 
 			// Adding the reserved IP range to the instance object
@@ -247,7 +247,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		// Add labels.
 		labels, err := extractLabels(param, s.config.driver.config.Name)
 		if err != nil {
-			return nil, err
+			return nil, file.StatusError(err)
 		}
 		newFiler.Labels = labels
 
@@ -260,7 +260,7 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 		if createErr != nil {
 			klog.Errorf("Create volume for volume Id %s failed: %v", volumeID, createErr.Error())
-			return nil, status.Error(*file.CodeForError(createErr), createErr.Error())
+			return nil, file.StatusError(createErr)
 		}
 	}
 	resp := &csi.CreateVolumeResponse{Volume: s.fileInstanceToCSIVolume(filer, modeInstance, sourceSnapshotId)}
@@ -333,7 +333,10 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 		duration := time.Since(start)
 		s.config.metricsManager.RecordOperationMetrics(err, methodDeleteVolume, modeMultishare, duration)
 		klog.Infof("Deletevolume response %+v error %v, for request: %+v", response, err, req)
-		return response, err
+		if err != nil {
+			return response, file.StatusError(err)
+		}
+		return response, nil
 	}
 
 	filer, _, err := getFileInstanceFromID(volumeID)
@@ -354,7 +357,7 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 		if file.IsNotFoundErr(err) {
 			return &csi.DeleteVolumeResponse{}, nil
 		}
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	if filer.State == "DELETING" {
@@ -364,7 +367,7 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 	err = s.config.fileService.DeleteInstance(ctx, filer)
 	if err != nil {
 		klog.Errorf("Delete volume for volume Id %s failed: %v", volumeID, err.Error())
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	klog.Infof("DeleteVolume succeeded for volume %v", volumeID)
@@ -391,7 +394,7 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 	filer.Project = s.config.cloud.Project
 	newFiler, err := s.config.fileService.GetInstance(ctx, filer)
 	if err != nil && !file.IsNotFoundErr(err) {
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 	if newFiler == nil {
 		return nil, status.Errorf(codes.NotFound, "volume %v doesn't exist", volumeID)
@@ -645,7 +648,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	filer.Project = s.config.cloud.Project
 	filer, err = s.config.fileService.GetInstance(ctx, filer)
 	if err != nil {
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 	if filer.State != "READY" {
 		return nil, fmt.Errorf("lolume %q is not yet ready, current state %q", volumeID, filer.State)
@@ -661,7 +664,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 
 	hasPendingOps, err := s.config.fileService.HasOperations(ctx, filer, "update", false /* done */)
 	if err != nil {
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	if hasPendingOps {
@@ -671,7 +674,7 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	filer.Volume.SizeBytes = reqBytes
 	newfiler, err := s.config.fileService.ResizeInstance(ctx, filer)
 	if err != nil {
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	klog.Infof("Controller expand volume succeeded for volume %v, new size(bytes): %v", volumeID, newfiler.Volume.SizeBytes)
@@ -840,12 +843,12 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	backupInfo, err := s.config.fileService.GetBackup(ctx, backupUri)
 	if err != nil {
 		if !file.IsNotFoundErr(err) {
-			return nil, status.Error(*file.CodeForError(err), err.Error())
+			return nil, file.StatusError(err)
 		}
 	} else {
 		backupSourceCSIHandle, err := util.BackupVolumeSourceToCSIVolumeHandle(backupInfo.SourceInstance, backupInfo.SourceShare)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Cannot determine volume handle from back source instance %s, share %s", backupInfo.SourceInstance, backupInfo.SourceShare)
+			return nil, status.Errorf(codes.InvalidArgument, "Cannot determine volume handle from back source instance %s, share %s", backupInfo.SourceInstance, backupInfo.SourceShare)
 		}
 		if backupSourceCSIHandle != volumeID {
 			return nil, status.Errorf(codes.AlreadyExists, "Backup already exists with a different source volume %s, input source volume %s", backupSourceCSIHandle, volumeID)
@@ -859,7 +862,8 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 		}
 		tp, err := util.ParseTimestamp(backupInfo.Backup.CreateTime)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to parse create timestamp for backup %v", backupInfo.Backup.Name)
+			err = fmt.Errorf("failed to parse create timestamp for backup %v: %w", backupInfo.Backup.Name, err)
+			return nil, file.StatusError(err)
 		}
 		klog.V(4).Infof("CreateSnapshot success for volume %v, Backup Id: %v", volumeID, backupInfo.Backup.Name)
 		return &csi.CreateSnapshotResponse{
@@ -876,13 +880,11 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	backupObj, err := s.config.fileService.CreateBackup(ctx, filer, req.Name, util.GetBackupLocation(req.GetParameters()))
 	if err != nil {
 		klog.Errorf("Create snapshot for volume Id %s failed: %v", volumeID, err.Error())
-		if err != nil {
-			return nil, status.Error(*file.CodeForError(err), err.Error())
-		}
+		return nil, file.StatusError(err)
 	}
 	tp, err := util.ParseTimestamp(backupObj.CreateTime)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, file.StatusError(err)
 	}
 	resp := &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
@@ -921,7 +923,7 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 			klog.Infof("Volume snapshot with ID %v not found", id)
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	if backupInfo.Backup.State == "DELETING" {
@@ -930,7 +932,7 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 
 	if err = s.config.fileService.DeleteBackup(ctx, id); err != nil {
 		klog.Errorf("Delete snapshot for backup Id %s failed: %v", id, err.Error())
-		return nil, status.Error(*file.CodeForError(err), err.Error())
+		return nil, file.StatusError(err)
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -1040,7 +1040,7 @@ func TestMultishareDeleteVolume(t *testing.T) {
 		errorExpected bool
 	}{
 		{
-			name: "share not found, instance not found, succes response",
+			name: "share not found, instance not found, success response",
 			req: &csi.DeleteVolumeRequest{
 				VolumeId: testVolId,
 			},

--- a/pkg/csi_driver/multishare_ops_manager.go
+++ b/pkg/csi_driver/multishare_ops_manager.go
@@ -71,7 +71,7 @@ func (m *MultishareOpsManager) setupEligibleInstanceAndStartWorkflow(ctx context
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, nil, status.Error(codes.Internal, err.Error())
+		return nil, nil, err
 	}
 	createShareOp := containsOpWithShareName(shareName, util.ShareCreate, ops)
 	if createShareOp != nil {
@@ -115,7 +115,7 @@ func (m *MultishareOpsManager) setupEligibleInstanceAndStartWorkflow(ctx context
 
 		needExpand, targetBytes, err := m.instanceNeedsExpand(ctx, share, share.CapacityBytes)
 		if err != nil {
-			return nil, nil, status.Error(codes.Internal, err.Error())
+			return nil, nil, err
 		}
 
 		if needExpand {
@@ -202,7 +202,7 @@ func (m *MultishareOpsManager) startShareCreateWorkflowSafe(ctx context.Context,
 	defer m.Unlock()
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return m.startShareWorkflow(ctx, &Workflow{share: share, opType: util.ShareCreate}, ops)
@@ -449,7 +449,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceOrShareExpandWorkflow(ctx co
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	expandShareOp, err := containsOpWithShareTarget(share, util.ShareUpdate, ops)
@@ -469,12 +469,12 @@ func (m *MultishareOpsManager) checkAndStartInstanceOrShareExpandWorkflow(ctx co
 
 	instance, err := m.cloud.File.GetMultishareInstance(ctx, share.Parent)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	needExpand, targetBytes, err := m.instanceNeedsExpand(ctx, share, reqBytes-share.CapacityBytes)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	if needExpand {
 		instance.CapacityBytes = targetBytes
@@ -491,7 +491,7 @@ func (m *MultishareOpsManager) startShareExpandWorkflowSafe(ctx context.Context,
 	defer m.Unlock()
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	share.CapacityBytes = reqBytes
@@ -504,7 +504,7 @@ func (m *MultishareOpsManager) checkAndStartShareDeleteWorkflow(ctx context.Cont
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	// If we find a running delete share op, poll for that to complete.
@@ -525,7 +525,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 
 	ops, err := m.listMultishareResourceRunningOps(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	err = m.verifyNoRunningInstanceOrShareOpsForInstance(instance, ops)
@@ -542,7 +542,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 		if file.IsNotFoundErr(err) {
 			return nil, nil
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	shares, err := m.cloud.File.ListShares(ctx, &file.ListFilter{Project: instance.Project, Location: instance.Location, InstanceName: instance.Name})
@@ -550,7 +550,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 		if file.IsNotFoundErr(err) {
 			return nil, nil
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	// Check for delete
@@ -560,7 +560,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 			if file.IsNotFoundErr(err) {
 				return nil, nil
 			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		return w, err
 	}
@@ -583,7 +583,7 @@ func (m *MultishareOpsManager) checkAndStartInstanceDeleteOrShrinkWorkflow(ctx c
 			if file.IsNotFoundErr(err) {
 				return nil, nil
 			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		return w, err
 	}


### PR DESCRIPTION
Cherry pick of #523 on release-1.4.

#523: Use CodeForError when we call filestore API, as well as when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```