### PR TITLE
issue-639: Add labels from command line option to filestore backup resource

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -292,13 +292,9 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 
 		// Add labels.
-		labels, err := extractLabels(param, s.config.driver.config.Name)
+		labels, err := extractLabels(param, s.config.extraVolumeLabels, s.config.driver.config.Name)
 		if err != nil {
 			return nil, file.StatusError(err)
-		}
-		// Append extra lables from the command line option
-		for k, v := range s.config.extraVolumeLabels {
-			labels[k] = v
 		}
 		newFiler.Labels = labels
 
@@ -836,7 +832,7 @@ func getZoneFromSegment(seg map[string]string) (string, error) {
 	return zone, nil
 }
 
-func extractLabels(parameters map[string]string, driverName string) (map[string]string, error) {
+func extractLabels(parameters, cliLabels map[string]string, driverName string) (map[string]string, error) {
 	labels := make(map[string]string)
 	scLables := make(map[string]string)
 	for k, v := range parameters {
@@ -857,12 +853,12 @@ func extractLabels(parameters map[string]string, driverName string) (map[string]
 	}
 
 	labels[tagKeyCreatedBy] = strings.ReplaceAll(driverName, ".", "_")
-	return mergeLabels(scLables, labels)
+	return mergeLabels(scLables, labels, cliLabels)
 }
 
-func mergeLabels(scLabels map[string]string, metedataLabels map[string]string) (map[string]string, error) {
+func mergeLabels(scLabels, metadataLabels, cliLabels map[string]string) (map[string]string, error) {
 	result := make(map[string]string)
-	for k, v := range metedataLabels {
+	for k, v := range metadataLabels {
 		result[k] = v
 	}
 
@@ -872,6 +868,14 @@ func mergeLabels(scLabels map[string]string, metedataLabels map[string]string) (
 		}
 
 		result[k] = v
+	}
+
+	// add labels from command line with precedence given to
+	// metadata and storage class labels in same order.
+	for k, v := range cliLabels {
+		if _, ok := result[k]; !ok {
+			result[k] = v
+		}
 	}
 
 	return result, nil
@@ -946,7 +950,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	} else {
 		// create new backup
 
-		labels, err := extractBackupLabels(req.GetParameters(), s.config.driver.config.Name, req.Name)
+		labels, err := extractBackupLabels(req.GetParameters(), s.config.extraVolumeLabels, s.config.driver.config.Name, req.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -976,8 +980,8 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 
 }
 
-func extractBackupLabels(parameters map[string]string, driverName string, snapshotName string) (map[string]string, error) {
-	labels, err := extractLabels(parameters, driverName)
+func extractBackupLabels(parameters, cliLabels map[string]string, driverName string, snapshotName string) (map[string]string, error) {
+	labels, err := extractLabels(parameters, cliLabels, driverName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -131,7 +131,10 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 						},
 					},
 				},
-				Parameters:         map[string]string{"tier": defaultTier},
+				Parameters: map[string]string{
+					"tier":             defaultTier,
+					ParameterKeyLabels: "key1=value1",
+				},
 				VolumeCapabilities: volumeCapabilities,
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -343,6 +346,34 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 				SourceVolumeId: modeInstance + "/" + testRegion + "/" + instanceName + "/" + shareName,
 			},
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				Parameters: map[string]string{
+					"tier":             enterpriseTier,
+					ParameterKeyLabels: "key1:value1",
+				},
+			},
+			resp:            nil,
+			expectedOptions: nil,
+			initialBackup: &BackupInfo{
+				s: &file.ServiceInstance{
+					Project:  testProject,
+					Location: testRegion,
+					Name:     instanceName,
+					Tier:     enterpriseTier,
+					Volume: file.Volume{
+						Name:      shareName,
+						SizeBytes: testBytes,
+					},
+				},
+				backupName:     backupName,
+				backupLocation: testRegion,
+				SourceVolumeId: modeInstance + "/" + testRegion + "/" + instanceName + "/" + shareName,
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {
@@ -359,8 +390,10 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 			SourceShare:        test.initialBackup.s.Volume.Name,
 			Name:               test.initialBackup.backupName,
 			SourceVolumeId:     test.initialBackup.SourceVolumeId,
-			BackupURI:          test.resp.Volume.ContentSource.GetSnapshot().SnapshotId,
 			Labels:             make(map[string]string),
+		}
+		if test.resp != nil {
+			backupInfo.BackupURI = test.resp.Volume.ContentSource.GetSnapshot().SnapshotId
 		}
 
 		cs.config.fileService.CreateBackup(context.TODO(), backupInfo)
@@ -1591,6 +1624,30 @@ func TestCreateSnapshot(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					ParameterKeyLabels:         "key1:value1",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1/myinstance/myshare",
+				},
+				state: "CREATING",
+			},
+			expectErr: true,
+		},
 		// Success test cases
 		{
 			name: "No backup found",
@@ -1678,6 +1735,30 @@ func TestCreateSnapshot(t *testing.T) {
 				Name:           backupName,
 				Parameters: map[string]string{
 					util.VolumeSnapshotTypeKey: "backup",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1-c/myinstance/myshare",
+				},
+			},
+		},
+		{
+			// If the incorrect labels were added, labels processing will not happen for already
+			// existing backup resources.
+			name: "Existing backup found, in state READY. Labels will not be processed.",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					ParameterKeyLabels:         "key1:value1",
 				},
 			},
 			initialBackup: &BackupTestInfo{
@@ -2100,6 +2181,322 @@ func TestParsingNfsExportOptions(t *testing.T) {
 		}
 		if !reflect.DeepEqual(test.expectedOptions, parsedOptions) {
 			t.Errorf("test %q failed; expected: %#v; got %#v", test.name, test.expectedOptions, parsedOptions)
+		}
+	}
+}
+
+func TestExtractLabels(t *testing.T) {
+	var (
+		driverName      = "test_driver"
+		pvcName         = "test_pvc"
+		pvcNamespace    = "test_pvc_namespace"
+		pvName          = "test_pv"
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
+	cases := []struct {
+		name         string
+		parameters   map[string]string
+		cliLabels    map[string]string
+		expectLabels map[string]string
+		expectError  string
+	}{
+		{
+			name: "Success case",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `parameters contain invalid labels parameter: labels "key1:value1,key2:value2" are invalid, correct format: 'key1=value1,key2=value2'`,
+		},
+		{
+			name: "storageClass labels contain reserved metadata label(kubernetes_io_created-for_pv_name)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1=value1,key2=value2,kubernetes_io_created-for_pv_name=test",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `storage Class labels cannot contain metadata label key kubernetes_io_created-for_pv_name`,
+		},
+		{
+			name: "storageClass labels parameter not present, only the CLI labels are defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels not defined, labels are defined only in the storageClass object",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels parameter not defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels has duplicates",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+	}
+	for _, test := range cases {
+		labels, err := extractLabels(test.parameters, test.cliLabels, driverName)
+		if (err != nil || test.expectError != "") && err.Error() != test.expectError {
+			t.Errorf("extractLabels(): %s: got: %v, expectErr: %v", test.name, err, test.expectError)
+		}
+		if !reflect.DeepEqual(test.expectLabels, labels) {
+			t.Errorf("extractLabels(): %s: got: %v, want: %v", test.name, labels, test.expectLabels)
+		}
+	}
+}
+
+func TestExtractBackupLabels(t *testing.T) {
+	var (
+		driverName      = "test_driver"
+		snapshotName    = "test_snapshot"
+		pvcName         = "test_pvc"
+		pvcNamespace    = "test_pvc_namespace"
+		pvName          = "test_pv"
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
+	cases := []struct {
+		name         string
+		parameters   map[string]string
+		cliLabels    map[string]string
+		expectLabels map[string]string
+		expectError  string
+	}{
+		{
+			name: "Success case",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `parameters contain invalid labels parameter: labels "key1:value1,key2:value2" are invalid, correct format: 'key1=value1,key2=value2'`,
+		},
+		{
+			name: "storageClass labels contain reserved metadata label(kubernetes_io_created-for_pv_name)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1=value1,key2=value2,kubernetes_io_created-for_pv_name=test",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `storage Class labels cannot contain metadata label key kubernetes_io_created-for_pv_name`,
+		},
+		{
+			name: "storageClass labels parameter not present, only the CLI labels are defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels not defined, labels are defined only in the storageClass object",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels parameter not defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels has duplicates",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+	}
+	for _, test := range cases {
+		labels, err := extractBackupLabels(test.parameters, test.cliLabels, driverName, snapshotName)
+		if (err != nil || test.expectError != "") && err.Error() != test.expectError {
+			t.Errorf("extractBackupLabels(): %s: got: %v, expectErr: %v", test.name, err, test.expectError)
+		}
+		if !reflect.DeepEqual(test.expectLabels, labels) {
+			t.Errorf("extractBackupLabels(): %s: got: %v, want: %v", test.name, labels, test.expectLabels)
 		}
 	}
 }

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -419,10 +419,15 @@ func TestGetShareRequestCapacity(t *testing.T) {
 }
 
 func TestExtractInstanceLabels(t *testing.T) {
+	var (
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
 	tests := []struct {
 		name          string
 		params        map[string]string
 		driver        string
+		cliLabels     map[string]string
 		expectedLabel map[string]string
 		expectErr     bool
 	}{
@@ -451,10 +456,108 @@ func TestExtractInstanceLabels(t *testing.T) {
 				TagKeyClusterLocation:                  testLocation,
 			},
 		},
+		{
+			name:   "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: nil,
+			expectErr:     true,
+		},
+		{
+			name:   "storageClass labels contain reserved metadata label(storage_gke_io_created-by)",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "key1=value1,key2=value2,storage_gke_io_created-by=test_filestore",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: nil,
+			expectErr:     true,
+		},
+		{
+			name:   "storageClass labels parameter not present, only the CLI labels are defined",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: map[string]string{
+				"key3":                                 "value3",
+				"key4":                                 "value4",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels not defined, labels are defined only in storageClass object",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             parameterLabels,
+			},
+			cliLabels: nil,
+			expectedLabel: map[string]string{
+				"key1":                                 "value1",
+				"key2":                                 "value2",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels and storageClass labels parameter not defined",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+			},
+			cliLabels: nil,
+			expectedLabel: map[string]string{
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels and storageClass labels has duplicates",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectedLabel: map[string]string{
+				"key1":                                 "value1",
+				"key2":                                 "value2",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			label, err := extractInstanceLabels(tc.params, tc.driver, testClusterName, testLocation)
+			label, err := extractInstanceLabels(tc.params, tc.cliLabels, tc.driver, testClusterName, testLocation)
 			if tc.expectErr && err == nil {
 				t.Error("expected error, got none")
 			}
@@ -2843,6 +2946,30 @@ func TestCreateMultishareSnapshot(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					"labels":                   "key1:value1",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            testProject,
+					Location:           testRegion,
+					SourceInstanceName: testInstanceName1,
+					SourceShare:        testShareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     modeMultishare + "/" + testRegion + "/" + testInstanceName1 + "/" + testShareName,
+				},
+				state: "CREATING",
+			},
+			expectErr: true,
+		},
 		//Success test cases
 		{
 			name: "No existing backup",
@@ -2871,6 +2998,32 @@ func TestCreateMultishareSnapshot(t *testing.T) {
 				Name:           backupName,
 				Parameters: map[string]string{
 					util.VolumeSnapshotTypeKey: "backup",
+				},
+			},
+			features: features,
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            testProject,
+					Location:           testRegion,
+					SourceInstanceName: testInstanceName1,
+					SourceShare:        testShareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     modeMultishare + "/" + testRegion + "/" + testInstanceName1 + "/" + testShareName,
+				},
+				state: "READY",
+			},
+		},
+		{
+			// If the incorrect labels were added, labels processing will not happen for already
+			// existing backup resources.
+			name: "Existing backup found, in state READY. Labels will not be processed.",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: defaultSourceVolumeID,
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					"labels":                   "key1:value1",
 				},
 			},
 			features: features,

--- a/pkg/csi_driver/reconciler.go
+++ b/pkg/csi_driver/reconciler.go
@@ -485,7 +485,7 @@ func (recon *MultishareReconciler) generateNewMultishareInstance(instanceInfo *v
 		}
 	}
 
-	labels, err := extractInstanceLabels(params, recon.config.Name, recon.config.ClusterName, clusterLocation)
+	labels, err := extractInstanceLabels(params, recon.config.ExtraVolumeLabels, recon.config.Name, recon.config.ClusterName, clusterLocation)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Adds labels from command line option to the filestore backup resource. Adding this change would keep the labels behavior in uniform with what's supported for filestore instance resource.
Labels added by driver, user defined labels in StorageClass object and labels passed through command line are parsed with precedence in the listed order.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #639

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
