### PR TITLE
Add NfsExportOptions parsing

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -91,8 +91,9 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Serv
 			Ip:              "1.1.1.1",
 			ReservedIpRange: obj.Network.ReservedIpRange,
 		},
-		Labels: obj.Labels,
-		State:  "READY",
+		Labels:           obj.Labels,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 
 	manager.createdInstances[obj.Name] = instance
@@ -219,8 +220,9 @@ func (manager *fakeServiceManager) CreateInstanceFromBackupSource(ctx context.Co
 			Ip:              "1.1.1.1",
 			ReservedIpRange: obj.Network.ReservedIpRange,
 		},
-		Labels: obj.Labels,
-		State:  "READY",
+		Labels:           obj.Labels,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 
 	manager.createdInstances[obj.Name] = instance
@@ -380,13 +382,14 @@ func (manager *fakeServiceManager) StartCreateShareOp(ctx context.Context, obj *
 		State:  "READY",
 	}
 	share := &Share{
-		Name:           obj.Name,
-		Parent:         parent,
-		CapacityBytes:  obj.CapacityBytes,
-		Labels:         obj.Labels,
-		MountPointName: obj.Name,
-		BackupId:       obj.BackupId,
-		State:          "READY",
+		Name:             obj.Name,
+		Parent:           parent,
+		CapacityBytes:    obj.CapacityBytes,
+		Labels:           obj.Labels,
+		MountPointName:   obj.Name,
+		BackupId:         obj.BackupId,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 	manager.createdMultishares[share.Name] = share
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -81,6 +83,7 @@ const (
 	paramMultishare                = "multishare"
 	ParamInstanceEncryptionKmsKey  = "instance-encryption-kms-key"
 	ParamMultishareInstanceScLabel = "instance-storageclass-label"
+	ParamNfsExportOptions          = "nfs-export-options-on-create"
 	paramMaxVolumeSize             = "max-volume-size"
 
 	// Keys for PV and PVC parameters as reported by external-provisioner
@@ -581,6 +584,7 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 
 	// Set default parameters
 	tier := defaultTier
+	var nfsExportOptions []*file.NfsExportOptions
 	network := defaultNetwork
 	connectMode := directPeering
 	kmsKeyName := ""
@@ -597,6 +601,11 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 					return nil, fmt.Errorf("failed to get region from zone %s: %w", location, err)
 				}
 				location = region
+			}
+		case ParamNfsExportOptions:
+			nfsExportOptions, err = parseNfsExportOptions(v)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to parse nfs-export-options-on-create %s: %v", v, err)
 			}
 		case paramNetwork:
 			network = v
@@ -631,7 +640,8 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 			Name:      newInstanceVolume,
 			SizeBytes: capBytes,
 		},
-		KmsKeyName: kmsKeyName,
+		KmsKeyName:       kmsKeyName,
+		NfsExportOptions: nfsExportOptions,
 	}, nil
 }
 
@@ -1000,4 +1010,22 @@ func (s *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSn
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil
+}
+
+func parseNfsExportOptions(optionsString string) ([]*file.NfsExportOptions, error) {
+	if optionsString == "" {
+		return nil, nil
+	}
+	var parsedOptions []*file.NfsExportOptions
+	err := strictUnmarshal([]byte(optionsString), &parsedOptions)
+	if err != nil {
+		return nil, err
+	}
+	return parsedOptions, nil
+}
+
+func strictUnmarshal(data []byte, v interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature
> /kind flake

**What this PR does / why we need it**:
Adds ability to process nfs-export-options-on-create from the SC's parameters and set it to filestore on volume create for single and multishare.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds ability to process nfs-export-options-on-create from the SC's parameters and set it to filestore on volume create for single and multishare.
```
