### PR TITLE
Fix issue where errors were reported as info

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -175,8 +175,13 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 		duration := time.Since(start)
 		s.config.metricsManager.RecordOperationMetrics(err, methodCreateVolume, modeMultishare, duration)
-		klog.Infof("CreateVolume response %+v error %v, for request %+v", response, err, req)
-		return response, err
+
+		if err != nil {
+			klog.Errorf("CreateVolume returned an error %v, for request %+v", err, req)
+			return nil, err
+		}
+		klog.Infof("CreateVolume response %v, for request %+v", response, req)
+		return response, nil
 	}
 
 	klog.V(4).Infof("CreateVolume called with request %+v", req)
@@ -385,10 +390,11 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 		}
 		duration := time.Since(start)
 		s.config.metricsManager.RecordOperationMetrics(err, methodDeleteVolume, modeMultishare, duration)
-		klog.Infof("Deletevolume response %+v error %v, for request: %+v", response, err, req)
 		if err != nil {
-			return response, file.StatusError(err)
+			klog.Errorf("Deletevolume returned error %v, for request: %+v", err, req)
+			return nil, file.StatusError(err)
 		}
+		klog.Infof("Deletevolume response %+v, for request: %+v", response, req)
 		return response, nil
 	}
 
@@ -683,8 +689,12 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 		}
 		duration := time.Since(start)
 		s.config.metricsManager.RecordOperationMetrics(err, methodExpandVolume, modeMultishare, duration)
-		klog.Infof("ControllerExpandVolume response %+v error %v, for request: %+v", response, err, req)
-		return response, err
+		if err != nil {
+			klog.Errorf("ControllerExpandVolume returned error %v, for request: %+v", err, req)
+			return nil, err
+		}
+		klog.Infof("ControllerExpandVolume response %+v, for request: %+v", response, req)
+		return response, nil
 	}
 
 	if acquired := s.config.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -876,8 +886,12 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 		response, err := s.config.multiShareController.CreateSnapshot(ctx, req)
 		duration := time.Since(start)
 		s.config.metricsManager.RecordOperationMetrics(err, methodCreateSnapshot, modeMultishare, duration)
-		klog.Infof("CreateSnapshot response %+v error %v, for request %+v", response, err, req)
-		return response, err
+		if err != nil {
+			klog.Errorf("CreateSnapshot returned error %v, for request %+v", err, req)
+			return nil, err
+		}
+		klog.Infof("CreateSnapshot response %+v, for request %+v", response, req)
+		return response, nil
 	}
 
 	if acquired := s.config.volumeLocks.TryAcquire(volumeID); !acquired {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Multishare operation errors are being reported with an "info" tag which makes them difficult to find

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix issue where errors were reported as Info for multishare operations
```
