### PR TITLE
Automated cherry pick of #737: Add NfsExportOptions parsing#770: Refactor duplicate function#774: Disable NFSExportOptions by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,8 @@ var (
 	coreInformerResyncPeriod   = flag.Duration("core-informer-resync-repriod", 15*time.Minute, "Core informer resync period.")
 
 	// Feature multishare backups enabled
-	featureMultishareBackups = flag.Bool("feature-multishare-backups", false, "if set to true, the multishare backups will be enabled. enable-multishare must be set to true as well")
+	featureMultishareBackups        = flag.Bool("feature-multishare-backups", false, "if set to true, the multishare backups will be enabled. enable-multishare must be set to true as well")
+	featureNFSExportOptionsOnCreate = flag.Bool("feature-nfs-export-options", false, "if set to true, the driver will accpet nfs-export-options-on-create parameter and configure IP Access rules")
 
 	// Feature stateful CSI driver specific parameters
 	featureStateful      = flag.Bool("feature-stateful-multishare", false, "if set to true, the controller will run stateful multishare controller, if set to true, enable-multishare must be set to true as well")
@@ -182,6 +183,9 @@ func main() {
 		},
 		FeatureMultishareBackups: &driver.FeatureMultishareBackups{
 			Enabled: *featureMultishareBackups,
+		},
+		FeatureNFSExportOptionsOnCreate: &driver.FeatureNFSExportOptionsOnCreate{
+			Enabled: *featureNFSExportOptionsOnCreate,
 		},
 	}
 

--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -91,8 +91,9 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Serv
 			Ip:              "1.1.1.1",
 			ReservedIpRange: obj.Network.ReservedIpRange,
 		},
-		Labels: obj.Labels,
-		State:  "READY",
+		Labels:           obj.Labels,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 
 	manager.createdInstances[obj.Name] = instance
@@ -219,8 +220,9 @@ func (manager *fakeServiceManager) CreateInstanceFromBackupSource(ctx context.Co
 			Ip:              "1.1.1.1",
 			ReservedIpRange: obj.Network.ReservedIpRange,
 		},
-		Labels: obj.Labels,
-		State:  "READY",
+		Labels:           obj.Labels,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 
 	manager.createdInstances[obj.Name] = instance
@@ -380,13 +382,14 @@ func (manager *fakeServiceManager) StartCreateShareOp(ctx context.Context, obj *
 		State:  "READY",
 	}
 	share := &Share{
-		Name:           obj.Name,
-		Parent:         parent,
-		CapacityBytes:  obj.CapacityBytes,
-		Labels:         obj.Labels,
-		MountPointName: obj.Name,
-		BackupId:       obj.BackupId,
-		State:          "READY",
+		Name:             obj.Name,
+		Parent:           parent,
+		CapacityBytes:    obj.CapacityBytes,
+		Labels:           obj.Labels,
+		MountPointName:   obj.Name,
+		BackupId:         obj.BackupId,
+		State:            "READY",
+		NfsExportOptions: obj.NfsExportOptions,
 	}
 	manager.createdMultishares[share.Name] = share
 

--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -93,6 +93,7 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Serv
 		},
 		Labels:           obj.Labels,
 		State:            "READY",
+		BackupSource:     obj.BackupSource,
 		NfsExportOptions: obj.NfsExportOptions,
 	}
 
@@ -203,30 +204,6 @@ func (manager *fakeServiceManager) GetBackup(ctx context.Context, backupUri stri
 	}
 
 	return backupInfo, nil
-}
-
-func (manager *fakeServiceManager) CreateInstanceFromBackupSource(ctx context.Context, obj *ServiceInstance, sourceSnapshotId string) (*ServiceInstance, error) {
-	instance := &ServiceInstance{
-		Project:  defaultProject,
-		Location: defaultZone,
-		Name:     obj.Name,
-		Tier:     obj.Tier,
-		Volume: Volume{
-			Name:      obj.Volume.Name,
-			SizeBytes: obj.Volume.SizeBytes,
-		},
-		Network: Network{
-			Name:            obj.Network.Name,
-			Ip:              "1.1.1.1",
-			ReservedIpRange: obj.Network.ReservedIpRange,
-		},
-		Labels:           obj.Labels,
-		State:            "READY",
-		NfsExportOptions: obj.NfsExportOptions,
-	}
-
-	manager.createdInstances[obj.Name] = instance
-	return instance, nil
 }
 
 func (m *fakeServiceManager) HasOperations(ctx context.Context, obj *ServiceInstance, operationType string, done bool) (bool, error) {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -604,9 +604,12 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 				location = region
 			}
 		case ParamNfsExportOptions:
+			if s.config.features.FeatureNFSExportOptionsOnCreate == nil || !s.config.features.FeatureNFSExportOptionsOnCreate.Enabled {
+				return nil, fmt.Errorf("nfsExportOptions are disabled")
+			}
 			nfsExportOptions, err = parseNfsExportOptions(v)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to parse nfs-export-options-on-create %s: %v", v, err)
+				return nil, fmt.Errorf("failed to parse nfs-export-options-on-create %s: %v", v, err)
 			}
 		case paramNetwork:
 			network = v

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -96,12 +96,17 @@ type GCFSDriverFeatureOptions struct {
 	// FeatureLockRelease will enable the NFS lock release feature if sets to true.
 	FeatureLockRelease *FeatureLockRelease
 	// FeatureMaxSharesPerInstance will enable CSI driver to pack configurable number of max shares per Filestore instance (multishare)
-	FeatureMaxSharesPerInstance *FeatureMaxSharesPerInstance
-	FeatureStateful             *FeatureStateful
-	FeatureMultishareBackups    *FeatureMultishareBackups
+	FeatureMaxSharesPerInstance     *FeatureMaxSharesPerInstance
+	FeatureStateful                 *FeatureStateful
+	FeatureMultishareBackups        *FeatureMultishareBackups
+	FeatureNFSExportOptionsOnCreate *FeatureNFSExportOptionsOnCreate
 }
 
 type FeatureMultishareBackups struct {
+	Enabled bool
+}
+
+type FeatureNFSExportOptionsOnCreate struct {
 	Enabled bool
 }
 

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -57,16 +57,17 @@ const (
 
 // MultishareController handles CSI calls for volumes which use Filestore multishare instances.
 type MultishareController struct {
-	driver                     *GCFSDriver
-	fileService                file.Service
-	cloud                      *cloud.Cloud
-	opsManager                 *MultishareOpsManager
-	volumeLocks                *util.VolumeLocks
-	ecfsDescription            string
-	isRegional                 bool
-	clustername                string
-	featureMaxSharePerInstance bool
-	featureMultishareBackups   bool
+	driver                          *GCFSDriver
+	fileService                     file.Service
+	cloud                           *cloud.Cloud
+	opsManager                      *MultishareOpsManager
+	volumeLocks                     *util.VolumeLocks
+	ecfsDescription                 string
+	isRegional                      bool
+	clustername                     string
+	featureMaxSharePerInstance      bool
+	featureMultishareBackups        bool
+	featureNFSExportOptionsOnCreate bool
 
 	// Filestore instance description overrides
 	descOverrideMaxSharesPerInstance string
@@ -102,6 +103,9 @@ func NewMultishareController(config *controllerServerConfig) *MultishareControll
 
 	if config.features != nil && config.features.FeatureMultishareBackups != nil {
 		c.featureMultishareBackups = config.features.FeatureMultishareBackups.Enabled
+	}
+	if config.features != nil && config.features.FeatureNFSExportOptionsOnCreate != nil {
+		c.featureNFSExportOptionsOnCreate = config.features.FeatureNFSExportOptionsOnCreate.Enabled
 	}
 
 	return c
@@ -572,6 +576,9 @@ func (m *MultishareController) generateNewMultishareInstance(instanceName string
 			kmsKeyName = v
 		// Ensure we don't flag the nfsExportOptions param as invalid. Value will be used when creating a new share
 		case ParamNfsExportOptions:
+			if !m.featureNFSExportOptionsOnCreate {
+				return nil, status.Error(codes.InvalidArgument, "nfsExportOptions are disabled")
+			}
 			continue
 		// Ignore the cidr flag as it is not passed to the cloud provider
 		// It will be used to get unreserved IP in the reserveIPV4Range function


### PR DESCRIPTION
Cherry pick of #737 #770 #774 on release-1.6.

#737: Add NfsExportOptions parsing
#770: Refactor duplicate function
#774: Disable NFSExportOptions by default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Add NfsExportOptions parsing behind a disabled flag
```