### PR TITLE
[Draft] Lock release improvement

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,8 +51,9 @@ var (
 	extraVolumeLabelsStr            = flag.String("extra-labels", "", "Extra labels to attach to each volume created. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'. See https://cloud.google.com/compute/docs/labeling-resources for details")
 
 	// Feature lock release specific parameters, only take effect when feature-lock-release is set to true.
-	featureLockRelease    = flag.Bool("feature-lock-release", false, "if set to true, the node driver will support Filestore lock release.")
-	lockReleaseSyncPeriod = flag.Duration("lock-release-sync-period", 60*time.Second, "Duration, in seconds, the sync period of the lock release controller. Defaults to 60 seconds.")
+	featureLockRelease         = flag.Bool("feature-lock-release", false, "if set to true, the node driver will support Filestore lock release.")
+	lockReleaseReconcilePeriod = flag.Duration("lock-release-reconcile-period", 60*time.Second, "Duration, in seconds, the reconcile period of the lock release controller. Defaults to 60 seconds.")
+	lockReleaseResyncPeriod    = flag.Duration("lock-release-resync-period", 10*time.Minute, "Duration, in minutes, the resync period of the informers cache. Defaults to 10 minutes.")
 
 	// Feature configurable shares per Filestore instance specific parameters.
 	featureMaxSharePerInstance = flag.Bool("feature-max-shares-per-instance", false, "If this feature flag is enabled, allows the user to configure max shares packed per Filestore instance")
@@ -154,12 +155,13 @@ func main() {
 		FeatureLockRelease: &driver.FeatureLockRelease{
 			Enabled: *featureLockRelease,
 			Config: &lockrelease.LockReleaseControllerConfig{
-				LeaseDuration:  *leaderElectionLeaseDuration,
-				RenewDeadline:  *leaderElectionRenewDeadline,
-				RetryPeriod:    *leaderElectionRetryPeriod,
-				SyncPeriod:     *lockReleaseSyncPeriod,
-				MetricEndpoint: *httpEndpoint,
-				MetricPath:     *metricsPath,
+				LeaseDuration:   *leaderElectionLeaseDuration,
+				RenewDeadline:   *leaderElectionRenewDeadline,
+				RetryPeriod:     *leaderElectionRetryPeriod,
+				ReconcilePeriod: *lockReleaseReconcilePeriod,
+				ResyncPeriod:    *lockReleaseResyncPeriod,
+				MetricEndpoint:  *httpEndpoint,
+				MetricPath:      *metricsPath,
 			},
 		},
 		FeatureMaxSharesPerInstance: &driver.FeatureMaxSharesPerInstance{

--- a/deploy/kubernetes/overlays/lockrelease/configmap_rbac.yaml
+++ b/deploy/kubernetes/overlays/lockrelease/configmap_rbac.yaml
@@ -12,7 +12,10 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["list", "watch"]
 
 ---
 
@@ -39,7 +42,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["get", "list", "update", "create"]
+  verbs: ["get", "update", "create"]
 
 ---
 

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -300,7 +300,7 @@ func (driver *GCFSDriver) ValidateControllerServiceRequest(c csi.ControllerServi
 func (driver *GCFSDriver) Run(endpoint string) {
 	klog.Infof("Running driver: %v", driver.config.Name)
 
-	run := func(ctx context.Context) {
+	run := func(_ context.Context) {
 		// run...
 		stopCh := make(chan struct{})
 		go driver.cs.(*controllerServer).Run(stopCh)

--- a/pkg/releaselock/configmap_util_test.go
+++ b/pkg/releaselock/configmap_util_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestParseConfigMapKey(t *testing.T) {
@@ -178,8 +178,8 @@ func TestGetConfigMap(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		objs := []runtime.Object{test.existingCM}
+		controller := NewFakeLockReleaseControllerWithClient(t, objs)
 		cm, err := controller.GetConfigMap(context.Background(), test.cmName, test.cmNamespace)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
@@ -273,8 +273,8 @@ func TestUpdateConfigMapWithKeyValue(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		objs := []runtime.Object{test.existingCM}
+		controller := NewFakeLockReleaseControllerWithClient(t, objs)
 		ctx := context.Background()
 		err := controller.UpdateConfigMapWithKeyValue(ctx, test.existingCM, test.key, test.value)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
@@ -371,8 +371,8 @@ func TestRemoveKeyFromConfigMap(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		objs := []runtime.Object{test.existingCM}
+		controller := NewFakeLockReleaseControllerWithClient(t, objs)
 		ctx := context.Background()
 		err := controller.RemoveKeyFromConfigMap(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
@@ -469,8 +469,8 @@ func TestRemoveKeyFromConfigMapWithRetry(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		objs := []runtime.Object{test.existingCM}
+		controller := NewFakeLockReleaseControllerWithClient(t, objs)
 		ctx := context.Background()
 		err := controller.RemoveKeyFromConfigMapWithRetry(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {

--- a/pkg/releaselock/controller_test.go
+++ b/pkg/releaselock/controller_test.go
@@ -1,13 +1,10 @@
 package lockrelease
 
 import (
-	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestVerifyNodeExists(t *testing.T) {
@@ -116,50 +113,5 @@ func TestVerifyNodeExists(t *testing.T) {
 		if nodeExists != test.expectExists {
 			t.Errorf("test %q failed: got nodeExists %t, expected %t", test.name, nodeExists, test.expectExists)
 		}
-	}
-}
-
-func TestListNodes(t *testing.T) {
-	node1 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node1",
-			Annotations: map[string]string{
-				gceInstanceIDKey: "node1-id",
-			},
-		},
-	}
-	node2 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node2",
-			Annotations: map[string]string{
-				gceInstanceIDKey: "node2-id",
-			},
-		},
-	}
-	controller := NewFakeLockReleaseControllerWithClient(fake.NewSimpleClientset(node1, node2))
-	expectedMap := map[string]*corev1.Node{
-		"node1": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Annotations: map[string]string{
-					gceInstanceIDKey: "node1-id",
-				},
-			},
-		},
-		"node2": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Annotations: map[string]string{
-					gceInstanceIDKey: "node2-id",
-				},
-			},
-		},
-	}
-	nodes, err := controller.listNodes(context.Background())
-	if err != nil {
-		t.Fatalf("test listNodes failed: unexpected error: %v", err)
-	}
-	if diff := cmp.Diff(expectedMap, nodes); diff != "" {
-		t.Errorf("test listNodes failed: unexpected diff (-want +got):%s", diff)
 	}
 }

--- a/pkg/releaselock/fake.go
+++ b/pkg/releaselock/fake.go
@@ -13,12 +13,56 @@ limitations under the License.
 
 package lockrelease
 
-import "k8s.io/client-go/kubernetes"
+import (
+	"testing"
+	"time"
+
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
 
 func NewFakeLockReleaseController() *LockReleaseController {
 	return &LockReleaseController{}
 }
 
-func NewFakeLockReleaseControllerWithClient(client kubernetes.Interface) *LockReleaseController {
-	return &LockReleaseController{client: client}
+func NewFakeLockReleaseControllerWithClient(t *testing.T, objs []runtime.Object) *LockReleaseController {
+	client := fake.NewSimpleClientset(objs...)
+	informer := informers.NewSharedInformerFactory(client, time.Hour /* disable resync*/)
+	configmapInformer := informer.Core().V1().ConfigMaps()
+
+	// Fill the informers with initial objects so controller can Get() them.
+	for _, obj := range objs {
+		switch obj.(type) {
+		case *v1.ConfigMap:
+			configmapInformer.Informer().GetStore().Add(obj)
+		default:
+			t.Fatalf("Unknown initalObject type: %+v", obj)
+		}
+	}
+
+	// This reactor makes sure that all updates that the controller does are
+	// reflected in its informers so Lister.Get() finds them. This does not
+	// enqueue events!
+	client.Fake.PrependReactor("create", "*", func(action core.Action) (bool, runtime.Object, error) {
+		if action.GetVerb() == "create" {
+			switch action.GetResource().Resource {
+			case "configmaps":
+				klog.V(5).Infof("Test reactor: updated configmap")
+				configmapInformer.Informer().GetStore().Add(action.(core.UpdateAction).GetObject())
+			default:
+				t.Errorf("Unknown update resource: %s", action.GetResource())
+			}
+		}
+		return false, nil, nil
+	})
+
+	return &LockReleaseController{
+		client:          client,
+		configmapLister: configmapInformer.Lister(),
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
The lock release controller will use informers to list configmap objects, and replace `LIST` node with `GET` nodes. This will reduce the API server load

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Lock release improvement - use informers to get or list node/configmap objects
```
