### PR TITLE
fix tier capacity check for expandVolume

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -990,6 +990,31 @@ func TestGetRequestCapacity(t *testing.T) {
 			tier:  basicHDDTier,
 			bytes: 1 * util.Tb,
 		},
+		{
+			name: "required in range ZONAL all cap",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 100 * util.Tb,
+			},
+			tier:  "ZONAL",
+			bytes: 100 * util.Tb,
+		},
+		{
+			name: "required above max BASIC_SSD all cap",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 70 * util.Tb,
+			},
+			tier:          "BASIC_SSD",
+			errorExpected: true,
+		},
+		{
+			name: "required and limit both in range BASIC_SSD all cap",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 3 * util.Tb,
+				LimitBytes:    60 * util.Tb,
+			},
+			tier:  "BASIC_SSD",
+			bytes: 3 * util.Tb,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
the capacity check is not working for tiers like enterprise and zonal when doing expandVolume

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fixed capacity check issue for non-default filestore tiers during ControllerExpandVolume
```
