### PR TITLE
Fix GCP tags UTs to not look for auth

### DIFF
--- a/pkg/cloud_provider/user_tags.go
+++ b/pkg/cloud_provider/user_tags.go
@@ -87,6 +87,11 @@ type resourceType string
 // resourceTags is the custom type for holding tags.
 type resourceTags map[string]struct{}
 
+// withoutAuthentication is for indicating to set WithoutAuthentication client
+// option when creating GCP tag client. Setting this will result in no other
+// authentication options being used.
+type withoutAuthentication struct{}
+
 // tagServiceManager handles resource tagging.
 type tagServiceManager struct {
 	*Cloud
@@ -97,6 +102,9 @@ type tagServiceManager struct {
 	// httpEndpoint is the endpoint used for tests and can be used
 	// with httpClient only.
 	httpEndpoint string
+	// withoutAuthentication is currently used only for tests. It can
+	// also be utilized for accessing public resources.
+	withoutAuthentication bool
 }
 
 // TagService is the interface that wraps methods for resource tag operations.
@@ -146,11 +154,11 @@ func (src *resourceTags) removeDuplicateTags() {
 
 // mergeTags merges tags from src to dst and removes
 // duplicate tags in dst after merge.
-func (src resourceTags) mergeTags(dst *resourceTags) {
+func (src *resourceTags) mergeTags(dst *resourceTags) {
 	if *dst == nil {
 		*dst = make(resourceTags)
 	}
-	for k, v := range src {
+	for k, v := range *src {
 		(*dst)[k] = v
 	}
 	dst.removeDuplicateTags()
@@ -169,11 +177,13 @@ func NewTagManager(cloud *Cloud, opts ...TagServiceOptions) TagService {
 // TagService arguments.
 func (t *tagServiceManager) parseTagServiceOptions(opts []TagServiceOptions) {
 	for _, opt := range opts {
-		switch opt.(type) {
+		switch val := opt.(type) {
 		case resourceTags:
-			t.tags = opt.(resourceTags)
+			t.tags = val
 		case *http.Client:
-			t.httpClient = opt.(*http.Client)
+			t.httpClient = val
+		case withoutAuthentication:
+			t.withoutAuthentication = true
 		}
 	}
 	return
@@ -221,13 +231,16 @@ func getTagCreateCallOptions() []gax.CallOption {
 // getTagClientOptions returns the tag client options adding the credentials and
 // the endpoint which will be used by the client.
 func (t *tagServiceManager) getTagClientOptions(ctx context.Context, endpoint string) ([]option.ClientOption, error) {
-	tokenSource, err := generateTokenSource(ctx, t.Config)
-	if err != nil {
-		return nil, err
-	}
+	opts := make([]option.ClientOption, 0)
 
-	opts := []option.ClientOption{
-		option.WithTokenSource(tokenSource),
+	if !t.withoutAuthentication {
+		tokenSource, err := generateTokenSource(ctx, t.Config)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, option.WithTokenSource(tokenSource))
+	} else {
+		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	if t.httpClient != nil {

--- a/pkg/cloud_provider/user_tags_test.go
+++ b/pkg/cloud_provider/user_tags_test.go
@@ -326,7 +326,7 @@ func TestValidateResourceTags(t *testing.T) {
 	})
 	defer server.Close()
 
-	tagMgr := NewTagManager(cloud, server.Client()).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, server.Client(), withoutAuthentication{}).(*tagServiceManager)
 	tagMgr.setTestHTTPEndpoint(server.URL)
 
 	for _, test := range cases {
@@ -349,7 +349,7 @@ func TestNewTagValuesClient(t *testing.T) {
 		t.Errorf("newTagValuesClient(): failed to create fake cloud provider object: %v", err)
 	}
 
-	tagMgr := NewTagManager(cloud).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, withoutAuthentication{}).(*tagServiceManager)
 	client, err := tagMgr.newTagValuesClient(ctx, "test/endpoint")
 	if err != nil {
 		t.Errorf("newTagValuesClient(): failed to create tag values client: %v", err)
@@ -363,7 +363,7 @@ func TestNewTagBindingsClient(t *testing.T) {
 		t.Errorf("newTagBindingsClient(): failed to create fake cloud provider object: %v", err)
 	}
 
-	tagMgr := NewTagManager(cloud).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, withoutAuthentication{}).(*tagServiceManager)
 	client, err := tagMgr.newTagBindingsClient(ctx, "test/endpoint")
 	if err != nil {
 		t.Errorf("newTagBindingsClient(): failed to create tag bindings client: %v", err)
@@ -475,7 +475,7 @@ func TestAttachResourceTags(t *testing.T) {
 	})
 	defer server.Close()
 
-	tagMgr := NewTagManager(cloud, server.Client()).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, server.Client(), withoutAuthentication{}).(*tagServiceManager)
 	tagMgr.setTestHTTPEndpoint(server.URL)
 
 	for _, test := range cases {
@@ -521,7 +521,7 @@ func TestValidateTagExist(t *testing.T) {
 	})
 	defer server.Close()
 
-	tagMgr := NewTagManager(cloud, server.Client()).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, server.Client(), withoutAuthentication{}).(*tagServiceManager)
 	client, err := tagMgr.newTagValuesClient(ctx, server.URL)
 	if err != nil {
 		t.Errorf("validateTagExist(): failed to create tag bindings client: %v", err)
@@ -610,7 +610,7 @@ func TestGetTagsToBind(t *testing.T) {
 	})
 	defer server.Close()
 
-	tagMgr := NewTagManager(cloud, argTags, server.Client()).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, argTags, server.Client(), withoutAuthentication{}).(*tagServiceManager)
 	client, err := tagMgr.newTagBindingsClient(ctx, server.URL)
 	if err != nil {
 		t.Errorf("getTagsToBind(): failed to create tag bindings client: %v", err)
@@ -698,7 +698,7 @@ func TestCreateTagBindings(t *testing.T) {
 	})
 	defer server.Close()
 
-	tagMgr := NewTagManager(cloud, server.Client()).(*tagServiceManager)
+	tagMgr := NewTagManager(cloud, server.Client(), withoutAuthentication{}).(*tagServiceManager)
 	client, err := tagMgr.newTagBindingsClient(ctx, server.URL)
 	if err != nil {
 		t.Errorf("createTagBindings(): failed to create tag bindings client: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Unit tests written for GCP tags was expecting the creds to be present which should not be case and hence the dependency is removed. And instead for UTs `WithoutAuthentication` is used.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
