### PR TITLE
Correct the path for directory creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Note that non-default networks require extra [firewall setup](https://cloud.goog
 * Clone the repository in cloudshell using following commands
 
 ```
-mkdir -p $GOPATH/src/sigs.k8s.io
-cd $GOPATH/src/sigs.k8s.io
+mkdir -p $GOPATH/src/github.com/kubernetes-sigs
+cd $GOPATH/src/github.com/kubernetes-sigs
 git clone https://github.com/kubernetes-sigs/gcp-filestore-csi-driver.git
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The current instruction to set up directory for contribution is incorrect. This gives error while running the cluster_setup.sh command.

**Which issue(s) this PR fixes**:
Fixes #918

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
