### PR TITLE
[release-1.6] issue-639: Add labels from command line option to filestore backup resource

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -133,7 +133,10 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 						},
 					},
 				},
-				Parameters:         map[string]string{"tier": defaultTier},
+				Parameters: map[string]string{
+					"tier":             defaultTier,
+					ParameterKeyLabels: "key1=value1",
+				},
 				VolumeCapabilities: volumeCapabilities,
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -345,6 +348,34 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 				SourceVolumeId: modeInstance + "/" + testRegion + "/" + instanceName + "/" + shareName,
 			},
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				Parameters: map[string]string{
+					"tier":             enterpriseTier,
+					ParameterKeyLabels: "key1:value1",
+				},
+			},
+			resp:            nil,
+			expectedOptions: nil,
+			initialBackup: &BackupInfo{
+				s: &file.ServiceInstance{
+					Project:  testProject,
+					Location: testRegion,
+					Name:     instanceName,
+					Tier:     enterpriseTier,
+					Volume: file.Volume{
+						Name:      shareName,
+						SizeBytes: testBytes,
+					},
+				},
+				backupName:     backupName,
+				backupLocation: testRegion,
+				SourceVolumeId: modeInstance + "/" + testRegion + "/" + instanceName + "/" + shareName,
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {
@@ -365,8 +396,10 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 			SourceShare:        test.initialBackup.s.Volume.Name,
 			Name:               test.initialBackup.backupName,
 			SourceVolumeId:     test.initialBackup.SourceVolumeId,
-			BackupURI:          test.resp.Volume.ContentSource.GetSnapshot().SnapshotId,
 			Labels:             make(map[string]string),
+		}
+		if test.resp != nil {
+			backupInfo.BackupURI = test.resp.Volume.ContentSource.GetSnapshot().SnapshotId
 		}
 
 		cs.config.fileService.CreateBackup(context.TODO(), backupInfo)
@@ -1643,6 +1676,30 @@ func TestCreateSnapshot(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					ParameterKeyLabels:         "key1:value1",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1/myinstance/myshare",
+				},
+				state: "CREATING",
+			},
+			expectErr: true,
+		},
 		// Success test cases
 		{
 			name: "No backup found",
@@ -1756,6 +1813,30 @@ func TestCreateSnapshot(t *testing.T) {
 			},
 			initialBackup: nil,
 			expectErr:     true,
+		},
+		{
+			// If the incorrect labels were added, labels processing will not happen for already
+			// existing backup resources.
+			name: "Existing backup found, in state READY. Labels will not be processed.",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1-c/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					ParameterKeyLabels:         "key1:value1",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            project,
+					Location:           region,
+					SourceInstanceName: instanceName,
+					SourceShare:        shareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     "modeInstance/us-central1-c/myinstance/myshare",
+				},
+			},
 		},
 	}
 	for _, test := range cases {
@@ -2182,6 +2263,322 @@ func TestParsingNfsExportOptions(t *testing.T) {
 		}
 		if !reflect.DeepEqual(test.expectedOptions, parsedOptions) {
 			t.Errorf("test %q failed; expected: %#v; got %#v", test.name, test.expectedOptions, parsedOptions)
+		}
+	}
+}
+
+func TestExtractLabels(t *testing.T) {
+	var (
+		driverName      = "test_driver"
+		pvcName         = "test_pvc"
+		pvcNamespace    = "test_pvc_namespace"
+		pvName          = "test_pv"
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
+	cases := []struct {
+		name         string
+		parameters   map[string]string
+		cliLabels    map[string]string
+		expectLabels map[string]string
+		expectError  string
+	}{
+		{
+			name: "Success case",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `parameters contain invalid labels parameter: labels "key1:value1,key2:value2" are invalid, correct format: 'key1=value1,key2=value2'`,
+		},
+		{
+			name: "storageClass labels contain reserved metadata label(kubernetes_io_created-for_pv_name)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1=value1,key2=value2,kubernetes_io_created-for_pv_name=test",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `storage Class labels cannot contain metadata label key kubernetes_io_created-for_pv_name`,
+		},
+		{
+			name: "storageClass labels parameter not present, only the CLI labels are defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels not defined, labels are defined only in the storageClass object",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels parameter not defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels has duplicates",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+			},
+		},
+	}
+	for _, test := range cases {
+		labels, err := extractLabels(test.parameters, test.cliLabels, driverName)
+		if (err != nil || test.expectError != "") && err.Error() != test.expectError {
+			t.Errorf("extractLabels(): %s: got: %v, expectErr: %v", test.name, err, test.expectError)
+		}
+		if !reflect.DeepEqual(test.expectLabels, labels) {
+			t.Errorf("extractLabels(): %s: got: %v, want: %v", test.name, labels, test.expectLabels)
+		}
+	}
+}
+
+func TestExtractBackupLabels(t *testing.T) {
+	var (
+		driverName      = "test_driver"
+		snapshotName    = "test_snapshot"
+		pvcName         = "test_pvc"
+		pvcNamespace    = "test_pvc_namespace"
+		pvName          = "test_pv"
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
+	cases := []struct {
+		name         string
+		parameters   map[string]string
+		cliLabels    map[string]string
+		expectLabels map[string]string
+		expectError  string
+	}{
+		{
+			name: "Success case",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `parameters contain invalid labels parameter: labels "key1:value1,key2:value2" are invalid, correct format: 'key1=value1,key2=value2'`,
+		},
+		{
+			name: "storageClass labels contain reserved metadata label(kubernetes_io_created-for_pv_name)",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       "key1=value1,key2=value2,kubernetes_io_created-for_pv_name=test",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: nil,
+			expectError:  `storage Class labels cannot contain metadata label key kubernetes_io_created-for_pv_name`,
+		},
+		{
+			name: "storageClass labels parameter not present, only the CLI labels are defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectLabels: map[string]string{
+				"key3":                         "value3",
+				"key4":                         "value4",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels not defined, labels are defined only in the storageClass object",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels parameter not defined",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+			},
+			cliLabels: nil,
+			expectLabels: map[string]string{
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+		{
+			name: "CLI labels and storageClass labels has duplicates",
+			parameters: map[string]string{
+				ParameterKeyPVCName:      pvcName,
+				ParameterKeyPVCNamespace: pvcNamespace,
+				ParameterKeyPVName:       pvName,
+				ParameterKeyLabels:       parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectLabels: map[string]string{
+				"key1":                         "value1",
+				"key2":                         "value2",
+				tagKeyCreatedForVolumeName:     pvName,
+				tagKeyCreatedForClaimName:      pvcName,
+				tagKeyCreatedForClaimNamespace: pvcNamespace,
+				tagKeyCreatedBy:                driverName,
+				tagKeySnapshotName:             snapshotName,
+			},
+		},
+	}
+	for _, test := range cases {
+		labels, err := extractBackupLabels(test.parameters, test.cliLabels, driverName, snapshotName)
+		if (err != nil || test.expectError != "") && err.Error() != test.expectError {
+			t.Errorf("extractBackupLabels(): %s: got: %v, expectErr: %v", test.name, err, test.expectError)
+		}
+		if !reflect.DeepEqual(test.expectLabels, labels) {
+			t.Errorf("extractBackupLabels(): %s: got: %v, want: %v", test.name, labels, test.expectLabels)
 		}
 	}
 }

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -68,6 +68,7 @@ type MultishareController struct {
 	featureMaxSharePerInstance      bool
 	featureMultishareBackups        bool
 	featureNFSExportOptionsOnCreate bool
+	extraVolumeLabels               map[string]string
 	tagManager                      cloud.TagService
 
 	// Filestore instance description overrides
@@ -82,14 +83,15 @@ type MultishareController struct {
 
 func NewMultishareController(config *controllerServerConfig) *MultishareController {
 	c := &MultishareController{
-		driver:          config.driver,
-		fileService:     config.fileService,
-		cloud:           config.cloud,
-		volumeLocks:     config.volumeLocks,
-		ecfsDescription: config.ecfsDescription,
-		isRegional:      config.isRegional,
-		clustername:     config.clusterName,
-		tagManager:      config.tagManager,
+		driver:            config.driver,
+		fileService:       config.fileService,
+		cloud:             config.cloud,
+		volumeLocks:       config.volumeLocks,
+		ecfsDescription:   config.ecfsDescription,
+		isRegional:        config.isRegional,
+		clustername:       config.clusterName,
+		extraVolumeLabels: config.extraVolumeLabels,
+		tagManager:        config.tagManager,
 	}
 	c.opsManager = NewMultishareOpsManager(config.cloud, c)
 	if config.features != nil && config.features.FeatureMaxSharesPerInstance != nil {
@@ -293,11 +295,12 @@ func (m *MultishareController) CreateSnapshot(ctx context.Context, req *csi.Crea
 			BackupURI:          backupURI,
 		}
 
-		labels, err := extractBackupLabels(req.GetParameters(), m.driver.config.Name, req.Name)
+		labels, err := extractBackupLabels(req.GetParameters(), m.extraVolumeLabels, m.driver.config.Name, req.Name)
 		if err != nil {
 			return nil, err
 		}
 		backupInfo.Labels = labels
+
 		snapshot, err := m.createNewBackup(ctx, backupInfo)
 		if err != nil {
 			return nil, err
@@ -617,7 +620,7 @@ func (m *MultishareController) generateNewMultishareInstance(instanceName string
 			return nil, status.Errorf(codes.InvalidArgument, "failed to get region for regional cluster: %v", err.Error())
 		}
 	}
-	labels, err := extractInstanceLabels(req.GetParameters(), m.driver.config.Name, m.clustername, location)
+	labels, err := extractInstanceLabels(req.GetParameters(), m.extraVolumeLabels, m.driver.config.Name, m.clustername, location)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
@@ -718,7 +721,7 @@ func (m *MultishareController) pickRegion(top *csi.TopologyRequirement) (string,
 	return region, nil
 }
 
-func extractInstanceLabels(parameters map[string]string, driverName, clusterName, location string) (map[string]string, error) {
+func extractInstanceLabels(parameters, cliLabels map[string]string, driverName, clusterName, location string) (map[string]string, error) {
 	instanceLabels := make(map[string]string)
 	userProvidedLabels := make(map[string]string)
 	for k, v := range parameters {
@@ -741,7 +744,7 @@ func extractInstanceLabels(parameters map[string]string, driverName, clusterName
 	instanceLabels[tagKeyCreatedBy] = strings.ReplaceAll(driverName, ".", "_")
 	instanceLabels[TagKeyClusterName] = clusterName
 	instanceLabels[TagKeyClusterLocation] = location
-	finalInstanceLabels, err := mergeLabels(userProvidedLabels, instanceLabels)
+	finalInstanceLabels, err := mergeLabels(userProvidedLabels, instanceLabels, cliLabels)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/csi_driver/reconciler.go
+++ b/pkg/csi_driver/reconciler.go
@@ -485,7 +485,7 @@ func (recon *MultishareReconciler) generateNewMultishareInstance(instanceInfo *v
 		}
 	}
 
-	labels, err := extractInstanceLabels(params, recon.config.Name, recon.config.ClusterName, clusterLocation)
+	labels, err := extractInstanceLabels(params, recon.config.ExtraVolumeLabels, recon.config.Name, recon.config.ClusterName, clusterLocation)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/640

```release-note
NONE
```

The automated cherry-pick https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/888 had merge conflicts, hence created a manual cherry-pick after rebase.

/assign @leiyiz 