### PR TITLE
Add small band support in the zonal Filestore tier

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -1015,6 +1015,54 @@ func TestGetRequestCapacity(t *testing.T) {
 			tier:  "BASIC_SSD",
 			bytes: 3 * util.Tb,
 		},
+		{
+			name: "required less than small ZONAL minimum capacity",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 100 * util.Gb,
+			},
+			tier:  "ZONAL",
+			bytes: 1 * util.Tb,
+		},
+		{
+			name: "required in small ZONAL range",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 3 * util.Tb,
+			},
+			tier:  "ZONAL",
+			bytes: 3 * util.Tb,
+		},
+		{
+			name: "required in small ZONAL range all cap",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 9984 * util.Gb,
+			},
+			tier:  "ZONAL",
+			bytes: 9984 * util.Gb,
+		},
+		{
+			name: "required in large ZONAL range",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 10 * util.Tb,
+			},
+			tier:  "ZONAL",
+			bytes: 10 * util.Tb,
+		},
+		{
+			name: "required in between small and large ZONAL range",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 9985 * util.Gb,
+			},
+			tier:  "ZONAL",
+			bytes: 10 * util.Tb,
+		},
+		{
+			name: "required above large ZONAL range",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 110 * util.Tb,
+			},
+			tier:          "ZONAL",
+			errorExpected: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup 

/kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Adds support for small zonal band in the Filestore zonal tier.

**Which issue(s) this PR fixes**:
Fixes #874

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added support for Filestore small zonal band (1 Ti - 9.75 Ti)
```
