### PR TITLE
Lock release unit test

### DIFF
--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -106,7 +106,7 @@ func initTestNodeServerWithKubeClient(t *testing.T, client kubernetes.Interface)
 		mounter:               mounter,
 		metaService:           metaserice,
 		volumeLocks:           util.NewVolumeLocks(),
-		lockReleaseController: lockrelease.NewFakeLockReleaseControllerWithClient(client),
+		lockReleaseController: lockrelease.NewControllerBuilder().WithClient(client).Build(),
 		features:              &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{Enabled: true}},
 	}
 }

--- a/pkg/releaselock/configmap_util_test.go
+++ b/pkg/releaselock/configmap_util_test.go
@@ -179,7 +179,7 @@ func TestGetConfigMap(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		controller := NewControllerBuilder().WithClient(client).Build()
 		cm, err := controller.GetConfigMap(context.Background(), test.cmName, test.cmNamespace)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Fatal(gotExpected)
@@ -274,7 +274,7 @@ func TestUpdateConfigMapWithKeyValue(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		controller := NewControllerBuilder().WithClient(client).Build()
 		ctx := context.Background()
 		err := controller.UpdateConfigMapWithKeyValue(ctx, test.existingCM, test.key, test.value)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
@@ -372,7 +372,7 @@ func TestRemoveKeyFromConfigMap(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		controller := NewControllerBuilder().WithClient(client).Build()
 		ctx := context.Background()
 		err := controller.RemoveKeyFromConfigMap(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
@@ -470,7 +470,7 @@ func TestRemoveKeyFromConfigMapWithRetry(t *testing.T) {
 	}
 	for _, test := range cases {
 		client := fake.NewSimpleClientset(test.existingCM)
-		controller := NewFakeLockReleaseControllerWithClient(client)
+		controller := NewControllerBuilder().WithClient(client).Build()
 		ctx := context.Background()
 		err := controller.RemoveKeyFromConfigMapWithRetry(ctx, test.existingCM, test.key)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {

--- a/pkg/releaselock/controller_test.go
+++ b/pkg/releaselock/controller_test.go
@@ -1,11 +1,49 @@
 package lockrelease
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+type MockEventProcessor struct {
+	mock.Mock
+}
+
+func (m *MockEventProcessor) processConfigMapEntryOnNodeCreation(ctx context.Context, key string, filestoreIP string, node *corev1.Node, cm *corev1.ConfigMap) error {
+	args := m.Called(ctx) // Pass the arguments used in On()
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	return nil
+}
+
+func (m *MockEventProcessor) processConfigMapEntryOnNodeUpdate(ctx context.Context, key string, filestoreIP string, newNode *corev1.Node, oldNode *corev1.Node, cm *corev1.ConfigMap) error {
+	args := m.Called(ctx)
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	return nil
+}
+
+type MockLockService struct {
+	mock.Mock
+}
+
+func (m *MockLockService) ReleaseLock(hostIP, clientIP string) error {
+	args := m.Called()
+	if args.Error(0) != nil {
+		return args.Error(0)
+	}
+	return nil
+}
+
+func (m *MockEventProcessor) SetController(ctrl *LockReleaseController) {}
 
 func TestVerifyConfigMapEntry(t *testing.T) {
 	cases := []struct {
@@ -105,13 +143,499 @@ func TestVerifyConfigMapEntry(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		controller := NewFakeLockReleaseController()
+		controller := NewControllerBuilder().Build()
 		nodeExists, err := controller.verifyConfigMapEntry(test.node, test.gceInstanceID, test.nodeInternalIP)
 		if gotExpected := gotExpectedError(test.name, test.expectErr, err); gotExpected != nil {
 			t.Errorf("%v", gotExpected)
 		}
 		if nodeExists != test.expectExists {
 			t.Errorf("test %q failed: got nodeExists %t, expected %t", test.name, nodeExists, test.expectExists)
+		}
+	}
+}
+
+func TestProcessConfigMapEntryOnNodeCreation(t *testing.T) {
+	cases := []struct {
+		name                  string
+		key                   string
+		filestoreIP           string
+		node                  *corev1.Node
+		cm                    *corev1.ConfigMap
+		lockReleaseError      bool
+		expectedError         bool
+		expectedConfigMapSize int
+	}{
+		{
+			name:        "should keep the entry",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "123456",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			lockReleaseError:      false,
+			expectedError:         false,
+			expectedConfigMapSize: 1,
+		},
+		{
+			name:        "should remove the entry due to node's absence in config map",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "changed_key",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			lockReleaseError:      false,
+			expectedError:         false,
+			expectedConfigMapSize: 0,
+		},
+		{
+			name:        "fail to remove the entry due to rpc call failure",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "changed_key",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			lockReleaseError:      true,
+			expectedError:         true,
+			expectedConfigMapSize: 1,
+		},
+	}
+	for _, test := range cases {
+		client := fake.NewSimpleClientset(test.cm, test.node)
+		eventProcessor := &DefaultEventProcessor{}
+		lockService := &MockLockService{}
+		if test.lockReleaseError {
+			lockService.On("ReleaseLock").Return(fmt.Errorf("fake lock release rpc call error"))
+		} else {
+			lockService.On("ReleaseLock").Return(nil)
+		}
+
+		c := NewControllerBuilder().WithClient(client).WithProcessor(eventProcessor).WithLockService(lockService).Build()
+		err := eventProcessor.processConfigMapEntryOnNodeCreation(context.Background(), test.key, test.filestoreIP, test.node, test.cm)
+		fmt.Printf("test case: %s processConfigMapEntryOnNodeCreation result, %v", test.name, err)
+		if err != nil && !test.expectedError {
+			t.Errorf("got an unexpected error")
+		}
+
+		if err == nil && test.expectedError {
+			t.Errorf("expected error but no error returned")
+		}
+		updatedCM, err := c.GetConfigMap(context.Background(), test.cm.Name, test.cm.Namespace)
+		if err != nil {
+			t.Error("error getting config map")
+		}
+		if got, want := len(updatedCM.Data), test.expectedConfigMapSize; got != want {
+			t.Errorf("expected resulting config map size: %d, but got %d", want, got)
+		}
+	}
+}
+
+func TestProcessConfigMapEntryOnNodeUpdate(t *testing.T) {
+	cases := []struct {
+		name                  string
+		key                   string
+		filestoreIP           string
+		newNode               *corev1.Node
+		oldNode               *corev1.Node
+		cm                    *corev1.ConfigMap
+		lockReleaseError      bool
+		expectedError         bool
+		expectedConfigMapSize int
+	}{
+		{
+			name:        "should keep the entry because new node matches config map entry",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "123456",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			oldNode:               &corev1.Node{},
+			lockReleaseError:      false,
+			expectedError:         false,
+			expectedConfigMapSize: 1,
+		},
+		{
+			name:        "should remove the entry because old node matches config map entry but new node does not",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "changed_key",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "123456",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			lockReleaseError:      false,
+			expectedError:         false,
+			expectedConfigMapSize: 0,
+		},
+		{
+			name:        "fail to remove the entry due to rpc call failure",
+			key:         "test-project.us-central1.test-filestore.test-share.123456.192_168_1_1",
+			filestoreIP: "192.168.92.0",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "changed_key",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "123456",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Address: "192.168.1.1", Type: corev1.NodeInternalIP}},
+				},
+			},
+			lockReleaseError:      true,
+			expectedError:         true,
+			expectedConfigMapSize: 1,
+		},
+	}
+	for _, test := range cases {
+		client := fake.NewSimpleClientset(test.cm)
+		eventProcessor := &DefaultEventProcessor{}
+		lockService := &MockLockService{}
+		if test.lockReleaseError {
+			lockService.On("ReleaseLock").Return(fmt.Errorf("fake lock release rpc call error"))
+		} else {
+			lockService.On("ReleaseLock").Return(nil)
+		}
+
+		c := NewControllerBuilder().WithClient(client).WithProcessor(eventProcessor).WithLockService(lockService).Build()
+		err := eventProcessor.processConfigMapEntryOnNodeUpdate(context.Background(), test.key, test.filestoreIP, test.newNode, test.oldNode, test.cm)
+		fmt.Printf("test case: %s processConfigMapEntryOnNodeUpdate result, %v", test.name, err)
+		if err != nil && !test.expectedError {
+			t.Errorf("got an unexpected error")
+		}
+
+		if err == nil && test.expectedError {
+			t.Errorf("expected error but no error returned")
+		}
+		updatedCM, err := c.GetConfigMap(context.Background(), test.cm.Name, test.cm.Namespace)
+		if err != nil {
+			t.Error("error getting config map")
+		}
+		if got, want := len(updatedCM.Data), test.expectedConfigMapSize; got != want {
+			t.Errorf("expected resulting config map size: %d, but got %d", want, got)
+		}
+	}
+}
+
+func TestHandleCreateEvent(t *testing.T) {
+	cases := []struct {
+		name                string
+		existingCM          *corev1.ConfigMap
+		obj                 interface{}
+		eventProcessorError bool
+		expectedError       bool
+	}{
+		{
+			name: "config map does not exist",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-not-exist",
+					Namespace: "gke-managed-filestorecsi",
+				},
+			},
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node1-id",
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "config map is found but config map processing returns error",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1":  "192.168.92.0",
+					"test-project.us-central1.test-filestore1.test-share.123456.192_168_1_1": "192.168.92.1",
+				},
+			},
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			eventProcessorError: true,
+			expectedError:       true,
+		},
+		{
+			name: "config map is found and all entries are processed successfully",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			eventProcessorError: false,
+			expectedError:       false,
+		},
+	}
+	for _, test := range cases {
+		client := fake.NewSimpleClientset(test.existingCM)
+		eventProcessor := &MockEventProcessor{}
+		if test.eventProcessorError {
+			eventProcessor.On("processConfigMapEntryOnNodeCreation", mock.Anything).Return(fmt.Errorf("mock processor error"))
+		} else {
+			eventProcessor.On("processConfigMapEntryOnNodeCreation", mock.Anything).Return(nil)
+		}
+		controller := NewControllerBuilder().WithClient(client).WithProcessor(eventProcessor).Build()
+		err := controller.handleCreateEvent(context.Background(), test.obj)
+		fmt.Printf("test case: %s handleCreateEvent result, %v", test.name, err)
+		if err != nil && !test.expectedError {
+			t.Errorf("got an unexpected error")
+		}
+
+		if err == nil && test.expectedError {
+			t.Errorf("expected error but no error returned")
+		}
+	}
+}
+
+func TestHandleUpdateEvent(t *testing.T) {
+	cases := []struct {
+		name                string
+		existingCM          *corev1.ConfigMap
+		oldObj              interface{}
+		newObj              interface{}
+		eventProcessorError bool
+		expectedError       bool
+	}{
+		{
+			name: "config map does not exist",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-not-exist",
+					Namespace: "gke-managed-filestorecsi",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node1-id",
+					},
+				},
+			},
+			oldObj:        &corev1.Node{},
+			expectedError: false,
+		},
+		{
+			name: "config map is found but config map processing returns error",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1":  "192.168.92.0",
+					"test-project.us-central1.test-filestore1.test-share.123456.192_168_1_1": "192.168.92.1",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			eventProcessorError: true,
+			expectedError:       true,
+		},
+		{
+			name: "config map is found and all entries are processed successfully",
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fscsi-node-name",
+					Namespace: "gke-managed-filestorecsi",
+				},
+				Data: map[string]string{
+					"test-project.us-central1.test-filestore.test-share.123456.192_168_1_1": "192.168.92.0",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-name",
+					Annotations: map[string]string{
+						gceInstanceIDKey: "node2-id",
+					},
+				},
+			},
+			eventProcessorError: false,
+			expectedError:       false,
+		},
+	}
+	for _, test := range cases {
+		client := fake.NewSimpleClientset(test.existingCM)
+		eventProcessor := &MockEventProcessor{}
+		if test.eventProcessorError {
+			eventProcessor.On("processConfigMapEntryOnNodeUpdate", mock.Anything).Return(fmt.Errorf("mock processor error"))
+		} else {
+			eventProcessor.On("processConfigMapEntryOnNodeUpdate", mock.Anything).Return(nil)
+		}
+		controller := NewControllerBuilder().WithClient(client).WithProcessor(eventProcessor).Build()
+		err := controller.handleUpdateEvent(context.Background(), test.oldObj, test.newObj)
+		fmt.Printf("test case: %s handleUpdateEvent result, %v", test.name, err)
+		if err != nil && !test.expectedError {
+			t.Errorf("got an unexpected error")
+		}
+
+		if err == nil && test.expectedError {
+			t.Errorf("expected error but no error returned")
 		}
 	}
 }

--- a/pkg/releaselock/fake.go
+++ b/pkg/releaselock/fake.go
@@ -15,10 +15,39 @@ package lockrelease
 
 import "k8s.io/client-go/kubernetes"
 
-func NewFakeLockReleaseController() *LockReleaseController {
-	return &LockReleaseController{}
+type FakeLockReleaseControllerBuilder struct {
+	client      kubernetes.Interface
+	processor   EventProcessor
+	lockService LockService
 }
 
-func NewFakeLockReleaseControllerWithClient(client kubernetes.Interface) *LockReleaseController {
-	return &LockReleaseController{client: client}
+func NewControllerBuilder() *FakeLockReleaseControllerBuilder {
+	return &FakeLockReleaseControllerBuilder{}
+}
+
+func (b *FakeLockReleaseControllerBuilder) WithClient(client kubernetes.Interface) *FakeLockReleaseControllerBuilder {
+	b.client = client
+	return b
+}
+
+func (b *FakeLockReleaseControllerBuilder) WithProcessor(processor EventProcessor) *FakeLockReleaseControllerBuilder {
+	b.processor = processor
+	return b
+}
+
+func (b *FakeLockReleaseControllerBuilder) WithLockService(lockService LockService) *FakeLockReleaseControllerBuilder {
+	b.lockService = lockService
+	return b
+}
+
+func (b *FakeLockReleaseControllerBuilder) Build() *LockReleaseController {
+	c := &LockReleaseController{
+		client:         b.client,
+		eventProcessor: b.processor,
+		lockService:    b.lockService,
+	}
+	if b.processor != nil {
+		b.processor.SetController(c)
+	}
+	return c
 }

--- a/pkg/releaselock/rpc.go
+++ b/pkg/releaselock/rpc.go
@@ -41,6 +41,8 @@ const (
 	notifyCloseChannelSize = 1
 )
 
+type FileStoreRPCClient struct{}
+
 type releaseLockResponse struct {
 	status releaseLockStatus
 }
@@ -69,7 +71,7 @@ func RegisterLockReleaseProcedure() error {
 // ReleaseLock calls the Filestore server to remove all advisory locks for a given GKE node IP.
 // hostIP is the internal IP address of the Filestore instance.
 // clientIP is the internal IP address of the GKE node.
-func ReleaseLock(hostIP, clientIP string) error {
+func (c *FileStoreRPCClient) ReleaseLock(hostIP, clientIP string) error {
 	// Check for valid IPV4 address.
 	if net.ParseIP(hostIP) == nil {
 		return fmt.Errorf("invalid Filestore IP address %s", hostIP)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Interface ReleaseLock rpc call to facilitate v2 lock release controller unit tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This PR is based on https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/973/files. Choose only the most recent commit to review.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
