### PR TITLE
Filestore NFSv4 support

### DIFF
--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -95,6 +95,7 @@ func (manager *fakeServiceManager) CreateInstance(ctx context.Context, obj *Serv
 		State:            "READY",
 		BackupSource:     obj.BackupSource,
 		NfsExportOptions: obj.NfsExportOptions,
+		Protocol:         obj.Protocol,
 	}
 
 	manager.createdInstances[obj.Name] = instance

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -144,8 +144,9 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 					CapacityBytes: defaultTierMinSize,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
 					},
 					ContentSource: &csi.VolumeContentSource{
 						Type: &csi.VolumeContentSource_Snapshot{
@@ -191,8 +192,9 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 					CapacityBytes: premiumTierMinSize,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
 					},
 					ContentSource: &csi.VolumeContentSource{
 						Type: &csi.VolumeContentSource_Snapshot{
@@ -230,7 +232,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 						},
 					},
 				},
-				Parameters:         map[string]string{"tier": enterpriseTier},
+				Parameters:         map[string]string{"tier": enterpriseTier, paramFileProtocol: v4_1FileProtocol},
 				VolumeCapabilities: volumeCapabilities,
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -238,8 +240,9 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 					CapacityBytes: testBytes,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v4_1FileProtocol,
 					},
 					ContentSource: &csi.VolumeContentSource{
 						Type: &csi.VolumeContentSource_Snapshot{
@@ -306,8 +309,9 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 					CapacityBytes: testBytes,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
 					},
 					ContentSource: &csi.VolumeContentSource{
 						Type: &csi.VolumeContentSource_Snapshot{
@@ -459,14 +463,50 @@ func TestCreateVolume(t *testing.T) {
 						},
 					},
 				},
+				Parameters: map[string]string{
+					"tier":     zonalTier,
+					"protocol": v4_1FileProtocol,
+				},
 			},
 			resp: &csi.CreateVolumeResponse{
 				Volume: &csi.Volume{
 					CapacityBytes: 1 * util.Tb,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v4_1FileProtocol,
+					},
+				},
+			},
+			features: features,
+		},
+		{
+			name: "create volume without providing protocol for basic",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					"tier": basicHDDTier,
+				},
+			},
+			resp: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					CapacityBytes: 1 * util.Tb,
+					VolumeId:      testVolumeID,
+					VolumeContext: map[string]string{
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
 					},
 				},
 			},
@@ -655,8 +695,9 @@ func TestCreateVolume(t *testing.T) {
 					CapacityBytes: 1 * util.Tb,
 					VolumeId:      testVolumeID,
 					VolumeContext: map[string]string{
-						attrIP:     testIP,
-						attrVolume: newInstanceVolume,
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
 					},
 				},
 			},
@@ -1106,6 +1147,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					Name:      newInstanceVolume,
 					SizeBytes: testBytes,
 				},
+				Protocol: v3FileProtocol,
 			},
 		},
 		{
@@ -1145,6 +1187,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					Name:      newInstanceVolume,
 					SizeBytes: testBytes,
 				},
+				Protocol: v3FileProtocol,
 			},
 		},
 		{
@@ -1189,6 +1232,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					Name:      newInstanceVolume,
 					SizeBytes: testBytes,
 				},
+				Protocol: v3FileProtocol,
 			},
 		},
 		{
@@ -1221,6 +1265,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					Name:      newInstanceVolume,
 					SizeBytes: testBytes,
 				},
+				Protocol: v3FileProtocol,
 			},
 		},
 		{
@@ -1261,6 +1306,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					Name:      newInstanceVolume,
 					SizeBytes: testBytes,
 				},
+				Protocol: v3FileProtocol,
 			},
 		},
 		{
@@ -1285,6 +1331,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					SizeBytes: testBytes,
 				},
 				KmsKeyName: "foo-key",
+				Protocol:   v3FileProtocol,
 			},
 		},
 		{
@@ -1310,6 +1357,7 @@ func TestGenerateNewFileInstance(t *testing.T) {
 					SizeBytes: testBytes,
 				},
 				KmsKeyName: "foo-key",
+				Protocol:   v3FileProtocol,
 			},
 		},
 		{

--- a/pkg/csi_driver/reconciler.go
+++ b/pkg/csi_driver/reconciler.go
@@ -248,7 +248,7 @@ func (recon *MultishareReconciler) sendShareRequests(instanceInfos map[string]*v
 		if assignedInstanceInfo.Status == nil || assignedInstanceInfo.Status.InstanceStatus != v1.READY || assignedInstanceInfo.Status.CapacityBytes < assignedInstanceInfo.Spec.CapacityBytes {
 			klog.Infof("Instance %s is not ready", assignedInstanceInfo.Name)
 			if assignedInstanceInfo.Status != nil && assignedInstanceInfo.Status.Error != "" {
-				recon.updateShareInfoErr(shareInfo, fmt.Errorf(assignedInstanceInfo.Status.Error))
+				recon.updateShareInfoErr(shareInfo, fmt.Errorf("%v", assignedInstanceInfo.Status.Error))
 			}
 			continue
 		}
@@ -487,7 +487,7 @@ func (recon *MultishareReconciler) generateNewMultishareInstance(instanceInfo *v
 
 	labels, err := extractInstanceLabels(params, recon.config.ExtraVolumeLabels, recon.config.Name, recon.config.ClusterName, clusterLocation)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	instance := &file.MultishareInstance{

--- a/pkg/util/ip_reservation_test.go
+++ b/pkg/util/ip_reservation_test.go
@@ -387,7 +387,7 @@ func getIPRanges(cidr string, ipRangesCount int, ipRangeSize int, t *testing.T) 
 		ipRanges[ipRangeString] = true
 	}
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	} else if i != ipRangesCount {
 		t.Fatalf("The required number of IP ranges %d are not available in the CIDR %s", ipRangesCount, cidr)
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -95,7 +95,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitHandler) {
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
 		msg := fmt.Sprintf("contentType=%s, expect application/json", contentType)
-		klog.Errorf(msg)
+		klog.Error(msg)
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
@@ -117,7 +117,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitHandler) {
 		requestedAdmissionReview, ok := obj.(*v1.AdmissionReview)
 		if !ok {
 			msg := fmt.Sprintf("Expected v1.AdmissionReview but got: %T", obj)
-			klog.Errorf(msg)
+			klog.Error(msg)
 			http.Error(w, msg, http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Adds support for Filestore NFSv4

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1000

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Default protocol type for Filestore instances is NFSv3. To create NFSv4 Filestore instances, specify a `protocol` parameter in storage class with value `NFS_V4_1`.
```
