### PR TITLE
Use SafeFormatAndMount for mounting.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
+	"k8s.io/utils/exec"
 	cloud "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider"
 	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
 	metadataservice "sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/metadata"
@@ -205,7 +206,7 @@ func main() {
 		},
 	}
 
-	mounter := mount.New("")
+	mounter := mount.NewSafeFormatAndMount(mount.New(""), exec.New())
 	config := &driver.GCFSDriverConfig{
 		Name:              driverName,
 		Version:           version,

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -56,13 +56,13 @@ const (
 )
 
 type GCFSDriverConfig struct {
-	Name              string          // Driver name
-	Version           string          // Driver version
-	NodeName          string          // Node name
-	RunController     bool            // Run CSI controller service
-	RunNode           bool            // Run CSI node service
-	Mounter           mount.Interface // Mount library
-	Cloud             *cloud.Cloud    // Cloud provider
+	Name              string                    // Driver name
+	Version           string                    // Driver version
+	NodeName          string                    // Node name
+	RunController     bool                      // Run CSI controller service
+	RunNode           bool                      // Run CSI node service
+	Mounter           *mount.SafeFormatAndMount // Mount library
+	Cloud             *cloud.Cloud              // Cloud provider
 	MetadataService   metadataservice.Service
 	EnableMultishare  bool
 	Reconciler        *MultishareReconciler

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -53,14 +53,14 @@ var (
 // TODO(b/375481562): refactor config map utils & remove node driver's dependency on lockReleaseController
 type nodeServer struct {
 	driver                *GCFSDriver
-	mounter               mount.Interface
+	mounter               *mount.SafeFormatAndMount
 	metaService           metadata.Service
 	volumeLocks           *util.VolumeLocks
 	lockReleaseController *lockrelease.LockReleaseController
 	features              *GCFSDriverFeatureOptions
 }
 
-func newNodeServer(driver *GCFSDriver, mounter mount.Interface, metaService metadata.Service, featureOptions *GCFSDriverFeatureOptions) (csi.NodeServer, error) {
+func newNodeServer(driver *GCFSDriver, mounter *mount.SafeFormatAndMount, metaService metadata.Service, featureOptions *GCFSDriverFeatureOptions) (csi.NodeServer, error) {
 	ns := &nodeServer{
 		driver:      driver,
 		mounter:     mounter,

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -56,7 +56,10 @@ func TestSanity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get cloud provider: %v", err)
 	}
-	mounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
+	fakeMounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
+	mounter := &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+	}
 
 	meta, err := metadata.NewFakeService()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR is a pre-requisite for enabling `read_ahead_kb` via CSI driver. For setting the `read_ahead_kb`, we need to execute the command with exec commands. The SafeFormatAndMount wrapper allows us to do that. This is aligned with pdcsi implementation - https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1627

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
