### PR TITLE
Added Small Basic support 

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -49,7 +49,7 @@ const (
 	v3FileProtocol   = "NFS_V3"
 	v4_1FileProtocol = "NFS_V4_1"
 
-	defaultTierMinSize    = 1 * util.Tb
+	defaultTierMinSize    = 100 * util.Gb
 	defaultTierMaxSize    = 639 * util.Tb / 10
 	enterpriseTierMinSize = 1 * util.Tb
 	enterpriseTierMaxSize = 10 * util.Tb
@@ -668,8 +668,6 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 			continue
 		case cloud.ParameterKeyResourceTags:
 			continue
-		case paramFileProtocol:
-			fileProtocol = v
 		case ParameterKeyLabels, ParameterKeyPVCName, ParameterKeyPVCNamespace, ParameterKeyPVName:
 		case "csiprovisionersecretname", "csiprovisionersecretnamespace":
 		default:

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -23,6 +23,7 @@ import (
 	csipb "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -93,6 +94,9 @@ func (c *CsiClient) CreateVolume(volName, zone, snapshotID string, parameters ma
 		Name:               volName,
 		VolumeCapabilities: stdVolCaps,
 		Parameters:         parameters,
+		CapacityRange: &csipb.CapacityRange{
+			RequiredBytes: 1 * util.Tb,
+		},
 	}
 	if zone != "" {
 		cvr.AccessibilityRequirements = &csi.TopologyRequirement{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Added Filestore small basic support. In this PR, the NFSv4 protocol configuration is removed. I'll add it once the fix for NFSv4 on Filestore end reaches Filestore prod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1068

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can create Filestore instances in Basic HDD tier with a minimum capacity of 100 GiB
```
