### PR TITLE
Round up max capacity if limit is not set

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -822,6 +822,22 @@ func TestGetRequestCapacity(t *testing.T) {
 			bytes: 1 * util.Tb,
 		},
 		{
+			name: "required above small zonal",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 11 * util.Tb,
+			},
+			tier:  zonalTier,
+			bytes: 11 * util.Tb,
+		},
+		{
+			name: "required in between small and large zonal",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 9990 * util.Gb,
+			},
+			tier:  zonalTier,
+			bytes: 10 * util.Tb,
+		},
+		{
 			name: "required above min",
 			capRange: &csi.CapacityRange{
 				RequiredBytes: 1*util.Tb + 1*util.Gb,
@@ -881,8 +897,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max default",
+			name: "required above max default with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    50 * util.Tb,
 				RequiredBytes: 100 * util.Tb,
 			},
 			tier:          defaultTier,
@@ -915,12 +932,21 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max enterprise",
+			name: "required above max enterprise with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    50 * util.Tb,
 				RequiredBytes: 100 * util.Tb,
 			},
 			tier:          enterpriseTier,
 			errorExpected: true,
+		},
+		{
+			name: "required above max enterprise without limit",
+			capRange: &csi.CapacityRange{
+				RequiredBytes: 100 * util.Tb,
+			},
+			tier:  enterpriseTier,
+			bytes: 100 * util.Tb,
 		},
 		{
 			name: "required and limit both in range enterprise",
@@ -940,8 +966,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max highScale",
+			name: "required above max highScale with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    100 * util.Tb,
 				RequiredBytes: 200 * util.Tb,
 			},
 			tier:          highScaleTier,
@@ -965,8 +992,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max premium",
+			name: "required above max premium with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    60 * util.Tb,
 				RequiredBytes: 70 * util.Tb,
 			},
 			tier:          premiumTier,
@@ -990,8 +1018,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max basicSSD",
+			name: "required above max basicSSD with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    639 * util.Tb / 10,
 				RequiredBytes: 70 * util.Tb,
 			},
 			tier:          basicSSDTier,
@@ -1015,8 +1044,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			errorExpected: true,
 		},
 		{
-			name: "required above max basicHDD",
+			name: "required above max basicHDD with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    639 * util.Tb / 10,
 				RequiredBytes: 70 * util.Tb,
 			},
 			tier:          basicHDDTier,
@@ -1040,8 +1070,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			bytes: 100 * util.Tb,
 		},
 		{
-			name: "required above max BASIC_SSD all cap",
+			name: "required above max BASIC_SSD all cap with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    639 * util.Tb / 10,
 				RequiredBytes: 70 * util.Tb,
 			},
 			tier:          "BASIC_SSD",
@@ -1097,8 +1128,9 @@ func TestGetRequestCapacity(t *testing.T) {
 			bytes: 10 * util.Tb,
 		},
 		{
-			name: "required above large ZONAL range",
+			name: "required above large ZONAL range with limit set",
 			capRange: &csi.CapacityRange{
+				LimitBytes:    100 * util.Tb,
 				RequiredBytes: 110 * util.Tb,
 			},
 			tier:          "ZONAL",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1059

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Provision a Filestore instance with max capacity if the required capacity is more than the max allowed and the LimitBytes are not set.
```
