### PR TITLE
Use protobuf encoding for core K8s APIs in lock release controller

### DIFF
--- a/cmd/lockrelease/main.go
+++ b/cmd/lockrelease/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -53,6 +54,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to create an in cluster config: %v", err)
 	}
+	config.ContentType = runtime.ContentTypeProtobuf
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		klog.Fatalf("Failed to create a new discovery client: %v", err)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -73,6 +74,7 @@ func newNodeServer(driver *GCFSDriver, mounter mount.Interface, metaService meta
 		if err != nil {
 			return nil, err
 		}
+		config.ContentType = kuberuntime.ContentTypeProtobuf
 		client, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			return nil, err

--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -233,6 +234,7 @@ func getKubeClient() (kubernetes.Interface, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %v", err)
 	}
+	config.ContentType = runtime.ContentTypeProtobuf
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/949 for the lock release controller v2 that didn't exist back then :).

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Use protobuf encoding for core k8s apis in lock release controller.
```