### PR TITLE
Enable NFSv4 behind feature flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,9 @@ var (
 	descOverrideMinShareSizeGB = flag.String("desc-override-min-shares-size-gb", "", "If non-empty, the filestore instance description override is used to configure min share size. This flag is ignored if 'feature-max-shares-per-instance' flag is false. Both 'desc-override-max-shares-per-instance' and 'desc-override-min-shares-size-gb' must be provided. 'ecfsDescription' is ignored, if this flag is provided.")
 	coreInformerResyncPeriod   = flag.Duration("core-informer-resync-repriod", 15*time.Minute, "Core informer resync period.")
 
+	// Feature Filestore NFSv4, only take effect when feature-nfs-v4 is set to true.
+	featureNFSv4Support = flag.Bool("feature-nfs-v4", false, "if set to true, the Filestore CSI driver will support NFSv4 support for Filestore.")
+
 	// Feature multishare backups enabled
 	featureMultishareBackups        = flag.Bool("feature-multishare-backups", false, "if set to true, the multishare backups will be enabled. enable-multishare must be set to true as well")
 	featureNFSExportOptionsOnCreate = flag.Bool("feature-nfs-export-options", false, "if set to true, the driver will accpet nfs-export-options-on-create parameter and configure IP Access rules")
@@ -202,6 +205,9 @@ func main() {
 		},
 		FeatureNFSExportOptionsOnCreate: &driver.FeatureNFSExportOptionsOnCreate{
 			Enabled: *featureNFSExportOptionsOnCreate,
+		},
+		FeatureNFSv4Support: &driver.FeatureNFSv4Support{
+			Enabled: *featureNFSv4Support,
 		},
 	}
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -670,6 +670,10 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 			continue
 		case cloud.ParameterKeyResourceTags:
 			continue
+		case paramFileProtocol:
+			if s.config.features.FeatureNFSv4Support.Enabled {
+				fileProtocol = v
+			}
 		case ParameterKeyLabels, ParameterKeyPVCName, ParameterKeyPVCNamespace, ParameterKeyPVName:
 		case "csiprovisionersecretname", "csiprovisionersecretnamespace":
 		default:

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -103,6 +103,7 @@ type GCFSDriverFeatureOptions struct {
 	FeatureStateful                 *FeatureStateful
 	FeatureMultishareBackups        *FeatureMultishareBackups
 	FeatureNFSExportOptionsOnCreate *FeatureNFSExportOptionsOnCreate
+	FeatureNFSv4Support             *FeatureNFSv4Support
 }
 
 type FeatureMultishareBackups struct {
@@ -110,6 +111,10 @@ type FeatureMultishareBackups struct {
 }
 
 type FeatureNFSExportOptionsOnCreate struct {
+	Enabled bool
+}
+
+type FeatureNFSv4Support struct {
 	Enabled bool
 }
 

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -303,7 +303,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	}
 
 	fileProtocol, ok := attr[attrFileProtocol]
-	if !ok {
+	if (s.features.FeatureNFSv4Support != nil && !s.features.FeatureNFSv4Support.Enabled) || !ok {
 		fileProtocol = v3FileProtocol
 	}
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -734,7 +734,11 @@ func initBlockingTestNodeServer(t *testing.T, operationUnblocker chan chan struc
 	if err != nil {
 		t.Fatalf("Failed to init metadata service")
 	}
-	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, &GCFSDriverFeatureOptions{FeatureLockRelease: &FeatureLockRelease{}})
+	featureOptions := &GCFSDriverFeatureOptions{
+		FeatureLockRelease:  &FeatureLockRelease{},
+		FeatureNFSv4Support: &FeatureNFSv4Support{},
+	}
+	ns, err := newNodeServer(initTestDriver(t), mounter, metaserice, featureOptions)
 	if err != nil {
 		t.Fatalf("Failed to create node server: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Enables Filestore NFSv4 support behind feature flag

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1000

**Special notes for your reviewer**:
Adding back the changes reverted in #1074

Tested this by enabling the feature explicitly in controller.yaml
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/93f18a36-6526-4c66-936a-c8bbd5a09251" />


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added NFSv4 support behind feature flag
```
