### PR TITLE
Allow users to specify source path to bind

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -471,8 +471,9 @@ func TestCreateVolume(t *testing.T) {
 					},
 				},
 				Parameters: map[string]string{
-					"tier":     zonalTier,
-					"protocol": v4_1FileProtocol,
+					"tier":        zonalTier,
+					"protocol":    v4_1FileProtocol,
+					"source-path": "marketing/dir1",
 				},
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -483,6 +484,7 @@ func TestCreateVolume(t *testing.T) {
 						attrIP:           testIP,
 						attrVolume:       newInstanceVolume,
 						attrFileProtocol: v4_1FileProtocol,
+						attrSourcePath:   "marketing/dir1",
 					},
 				},
 			},

--- a/pkg/csi_driver/multishare_controller.go
+++ b/pkg/csi_driver/multishare_controller.go
@@ -233,6 +233,11 @@ func (m *MultishareController) CreateVolume(ctx context.Context, req *csi.Create
 		return nil, common.NewTemporaryError(codes.Unavailable, fmt.Errorf("%v operation %q poll error: %w", shareCreateWorkflow.opType, shareCreateWorkflow.opName, err))
 	}
 	resp, err := m.getShareAndGenerateCSICreateVolumeResponse(ctx, instanceScPrefix, newShare, maxShareSizeSizeBytes)
+
+	if p := getSourcePathFromParameters(req.GetParameters()); p != "" {
+		resp.Volume.VolumeContext[attrSourcePath] = p
+	}
+
 	return resp, file.StatusError(err)
 }
 

--- a/pkg/csi_driver/multishare_stateful_controller.go
+++ b/pkg/csi_driver/multishare_stateful_controller.go
@@ -153,7 +153,14 @@ func (m *MultishareStatefulController) CreateVolume(ctx context.Context, req *cs
 	if err != nil {
 		return nil, err
 	}
-	return m.mc.getShareAndGenerateCSICreateVolumeResponse(ctx, instanceSCLabel, share, maxShareSizeBytes)
+
+	resp, err := m.mc.getShareAndGenerateCSICreateVolumeResponse(ctx, instanceSCLabel, share, maxShareSizeBytes)
+
+	if p := getSourcePathFromParameters(req.GetParameters()); p != "" {
+		resp.Volume.VolumeContext[attrSourcePath] = p
+	}
+
+	return resp, err
 }
 
 func (m *MultishareStatefulController) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -270,6 +270,7 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	// Validate volume attributes
 	var source string
 	attr := req.GetVolumeContext()
+	sourcePath := attr[attrSourcePath]
 	if isMultishareVolId(volumeID) {
 		if err := validateMultishareVolumeAttributes(attr); err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -278,12 +279,12 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		source = fmt.Sprintf("%s:/%s", attr[attrIP], shareName)
+		source = fmt.Sprintf("%s:/%s/%s", attr[attrIP], shareName, sourcePath)
 	} else {
 		if err := validateVolumeAttributes(attr); err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		source = fmt.Sprintf("%s:/%s", attr[attrIP], attr[attrVolume])
+		source = fmt.Sprintf("%s:/%s/%s", attr[attrIP], attr[attrVolume], sourcePath)
 	}
 
 	if acquired := s.volumeLocks.TryAcquire(volumeID); !acquired {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR will allow users to specify a source path to bind. This is particularly useful in cases where the user wants to bind subdirectories.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow users to specify source path to bind
```
