### PR TITLE
Add mount options support in the createVolume method

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -711,6 +711,40 @@ func TestCreateVolume(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "create volume with mount options",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					"tier":          zonalTier,
+					"protocol":      v4_1FileProtocol,
+					"mount-options": "noatime,nodiratime",
+				},
+			},
+			resp: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					CapacityBytes: 1 * util.Tb,
+					VolumeId:      testVolumeID,
+					VolumeContext: map[string]string{
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v4_1FileProtocol,
+						attrMountOptions: "noatime,nodiratime",
+					},
+				},
+			},
+			features: features,
+		},
 	}
 
 	for _, test := range cases {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -95,6 +95,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	readOnly := req.GetReadonly()
 	targetPath := req.GetTargetPath()
 	stagingTargetPath := req.GetStagingTargetPath()
+	volumeContext := req.GetVolumeContext()
 	if len(targetPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume target path must be provided")
 	}
@@ -157,6 +158,10 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 	if capMount := req.GetVolumeCapability().GetMount(); capMount != nil {
 		options = append(options, capMount.GetMountFlags()...)
+	}
+
+	if mountOptions := volumeContext[attrMountOptions]; mountOptions != "" {
+		options = append(options, mountOptions)
 	}
 
 	err = s.mounter.Mount(stagingTargetPath, targetPath, fstype, options)
@@ -332,6 +337,10 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		for _, flag := range mnt.MountFlags {
 			options = append(options, flag)
 		}
+	}
+
+	if mountOptions := attr[attrMountOptions]; mountOptions != "" {
+		options = append(options, mountOptions)
 	}
 
 	err = s.mounter.Mount(source, stagingTargetPath, fstype, options)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -333,6 +333,22 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "valid request with mountOptions in VolumeContext",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingTargetPath,
+				TargetPath:        testTargetPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					attrIP:           "1.1.1.1",
+					attrVolume:       "test-volume",
+					attrMountOptions: "noatime,nodiratime",
+				},
+			},
+			actions:       []mount.FakeAction{{Action: mount.FakeActionMount}},
+			expectedMount: &mount.MountPoint{Device: stagingTargetPath, Path: testTargetPath, Type: "nfs", Opts: []string{"bind", "noatime,nodiratime"}},
+		},
 		// TODO: Revisit this (https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/issues/47).
 		// {
 		// 	name: "target path doesn't exist",
@@ -1035,6 +1051,50 @@ func TestNodeStageVolumeUpdateLockInfo(t *testing.T) {
 		if diff := cmp.Diff(test.expectedCM, cm); diff != "" {
 			t.Errorf("test %q failed: unexpected diff (-want +got):\n%s", test.name, diff)
 		}
+	}
+}
+
+func TestNodeStageVolume_AppendsMountOptions(t *testing.T) {
+	testEnv := initTestNodeServer(t)
+	attr := map[string]string{
+		attrIP:           "10.0.0.1",
+		attrVolume:       "vol1",
+		attrMountOptions: "hard,intr",
+	}
+	req := &csi.NodeStageVolumeRequest{
+		VolumeId:          "vol-test",
+		StagingTargetPath: "/tmp/stage",
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+		VolumeContext: attr,
+	}
+
+	_, err := testEnv.ns.NodeStageVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("NodeStageVolume failed: %v", err)
+	}
+
+	fm := testEnv.fm
+	if len(fm.MountPoints) == 0 {
+		t.Fatalf("expected a mount call")
+	}
+	found := false
+	for _, mp := range fm.MountPoints {
+		for _, opt := range mp.Opts {
+			if opt == "hard,intr" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected mount options 'hard,intr' to be present in mount call")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR enables customers to specify NFS mount options in the storage class using parameters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1123

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note 
This change will allow users to specify NFS mount options in the storage class using parameters.

```
