### PR TITLE
Change verbosity level of node informer event logs

### DIFF
--- a/cmd/lockrelease/main.go
+++ b/cmd/lockrelease/main.go
@@ -79,11 +79,11 @@ func main() {
 
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			klog.Infof("Node informer received node create event. %v", obj)
+			klog.V(8).Infof("Node informer received node create event. %v", obj)
 			c.EnqueueCreateEventObject(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			klog.Infof("Node informer received node update event. old %v, new %v", oldObj, newObj)
+			klog.V(8).Infof("Node informer received node update event. old %v, new %v", oldObj, newObj)
 			c.EnqueueUpdateEventObject(oldObj, newObj)
 		},
 	})

--- a/pkg/releaselock/controller.go
+++ b/pkg/releaselock/controller.go
@@ -416,7 +416,7 @@ func (c *LockReleaseController) processNextCreateEvent(ctx context.Context) bool
 		// If no error occurs then we Forget this item so it does not
 		// get queued again until another change happens.
 		c.createEventQueue.Forget(obj)
-		klog.Infof("Successfully processed node create event object %v", obj)
+		klog.V(8).Infof("Successfully processed node create event object %v", obj)
 		return true
 	}
 
@@ -452,7 +452,7 @@ func (c *LockReleaseController) processNextUpdateEventWorkItem(ctx context.Conte
 		// If no error occurs then we Forget this item so it does not
 		// get queued again until another change happens.
 		c.updateEventQueue.Forget(obj)
-		klog.Infof("Successfully processed node update event object %v", obj)
+		klog.V(8).Infof("Successfully processed node update event object %v", obj)
 		return true
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR will change verbosity level of node informer event logs to reduce the logs volume size.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1139

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
