### PR TITLE
Fix typo in feature-nfs-v4 flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,7 +64,7 @@ var (
 	coreInformerResyncPeriod   = flag.Duration("core-informer-resync-repriod", 15*time.Minute, "Core informer resync period.")
 
 	// Feature Filestore NFSv4, only take effect when feature-nfs-v4 is set to true.
-	featureNFSv4Support = flag.Bool("feature-nfs-v4", false, "if set to true, the Filestore CSI driver will support NFSv4 support for Filestore.")
+	featureNFSv4Support = flag.Bool("feature-nfs-v4", false, "if set to true, the Filestore CSI driver will support using the NFSv4 protocol for mounting Filestore instances.")
 
 	// Feature multishare backups enabled
 	featureMultishareBackups        = flag.Bool("feature-multishare-backups", false, "if set to true, the multishare backups will be enabled. enable-multishare must be set to true as well")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The previous flag help info `if set to true, the Filestore CSI driver will support NFSv4 support for Filestore.` made a bit confused, 2 duplicated `support`, this fix commit makes the help info more clearly.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
