### PR TITLE
fix: adjust IP range size selection to include zonal and regional tie…

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -375,10 +375,10 @@ func (s *controllerServer) reserveIPRange(ctx context.Context, filer *file.Servi
 		return "", err
 	}
 	ipRangeSize := util.IpRangeSize
-	if filer.Tier == enterpriseTier {
+	if filer.Tier == enterpriseTier || filer.Tier == zonalTier || filer.Tier == regionalTier {
 		ipRangeSize = util.IpRangeSizeEnterprise
 	}
-	if filer.Tier == highScaleTier || filer.Tier == zonalTier || filer.Tier == regionalTier {
+	if filer.Tier == highScaleTier {
 		ipRangeSize = util.IpRangeSizeHighScale
 	}
 	unreservedIPBlock, err := s.config.ipAllocator.GetUnreservedIPRange(cidr, ipRangeSize, cloudInstancesReservedIPRanges)

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -802,6 +802,38 @@ func TestCreateVolume(t *testing.T) {
 			features: features,
 		},
 		{
+			name: "create volume with zonal tier",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					"tier":               zonalTier,
+					"reserved-ipv4-cidr": testReservedIPV4CIDR,
+				},
+			},
+			resp: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					CapacityBytes: 1 * util.Tb,
+					VolumeId:      testVolumeID,
+					VolumeContext: map[string]string{
+						attrIP:           testIP,
+						attrVolume:       newInstanceVolume,
+						attrFileProtocol: v3FileProtocol,
+					},
+				},
+			},
+			features: features,
+		},
+		{
 			name: "create volume with valid performance config",
 			req: &csi.CreateVolumeRequest{
 				Name: testCSIVolume,
@@ -918,7 +950,7 @@ func TestCreateVolume(t *testing.T) {
 			}
 		}
 		if !test.expectErr && test.req.Parameters[ParamReservedIPV4CIDR] != "" {
-			expectedReservedIpRange := "10.0.0.0/24"
+			expectedReservedIpRange := "10.0.0.0/26"
 			instance, err := cs.config.fileService.GetInstance(context.TODO(), &file.ServiceInstance{Name: test.req.Name})
 			if err != nil {
 				t.Errorf("test %q failed: couldn't get instance %v: %v", test.name, test.req.Name, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adjust IP range size selection to include zonal and regional tiers in enterprise logic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
