### PR TITLE
do not count user errors 409 already exists errors against SLO

### DIFF
--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -234,6 +234,7 @@ var userErrorCodeMap = map[int]codes.Code{
 	http.StatusBadRequest:      codes.InvalidArgument,
 	http.StatusTooManyRequests: codes.ResourceExhausted,
 	http.StatusNotFound:        codes.NotFound,
+	http.StatusConflict:        codes.AlreadyExists,
 }
 
 func NewGCFSService(version string, client *http.Client, primaryFilestoreServiceEndpoint, testFilestoreServiceEndpoint string) (Service, error) {
@@ -743,6 +744,7 @@ func IsNotFoundErr(err error) bool {
 // (2) http 403 Forbidden, returns grpc PermissionDenied,
 // (3) http 404 Not Found, returns grpc NotFound
 // (4) http 429 Too Many Requests, returns grpc ResourceExhausted
+// (5) http 409 Conflict, returns grpc AlreadyExists
 func isUserOperationError(err error) *codes.Code {
 	// Upwrap the error
 	var apiErr *googleapi.Error
@@ -771,6 +773,9 @@ func containsUserErrStr(err error) *codes.Code {
 	}
 	if strings.Contains(err.Error(), "NOT_FOUND") {
 		return util.ErrCodePtr(codes.NotFound)
+	}
+	if strings.Contains(err.Error(), "ALREADY_EXISTS") {
+		return util.ErrCodePtr(codes.AlreadyExists)
 	}
 	return nil
 }
@@ -870,6 +875,7 @@ func isGoogleAPIError(err error) *codes.Code {
 // (2) http 403 Forbidden, returns grpc PermissionDenied,
 // (3) http 404 Not Found, returns grpc NotFound
 // (4) http 429 Too Many Requests, returns grpc ResourceExhausted
+// (5) http 409 Conflict, returns grpc AlreadyExists
 // The following errors are considered context errors:
 // (1) "context deadline exceeded", returns grpc DeadlineExceeded,
 // (2) "context canceled", returns grpc Canceled

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -741,6 +741,11 @@ func TestCodeForError(t *testing.T) {
 			expectedErrCode: util.ErrCodePtr(codes.ResourceExhausted),
 		},
 		{
+			name:            "apierror.APIError  wrapped 409 http error",
+			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusConflict}),
+			expectedErrCode: util.ErrCodePtr(codes.AlreadyExists),
+		},
+		{
 			name:            "apierror.APIError  wrapped 400 http error",
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusBadRequest}),
 			expectedErrCode: util.ErrCodePtr(codes.InvalidArgument),
@@ -789,6 +794,16 @@ func TestCodeForError(t *testing.T) {
 			name:            "wrapped 404 googleapi error",
 			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusNotFound}),
 			expectedErrCode: util.ErrCodePtr(codes.NotFound),
+		},
+		{
+			name:            "409 googleapi error",
+			err:             &googleapi.Error{Code: http.StatusConflict},
+			expectedErrCode: util.ErrCodePtr(codes.AlreadyExists),
+		},
+		{
+			name:            "wrapped 409 googleapi error",
+			err:             fmt.Errorf("got error: %w", &googleapi.Error{Code: http.StatusConflict}),
+			expectedErrCode: util.ErrCodePtr(codes.AlreadyExists),
 		},
 		{
 			name:            "status error with Aborted error code",
@@ -876,6 +891,11 @@ func TestIsUserError(t *testing.T) {
 			name:            "NOT_FOUND error",
 			err:             fmt.Errorf("got error: NOT_FOUND"),
 			expectedErrCode: util.ErrCodePtr(codes.NotFound),
+		},
+		{
+			name:            "ALREADY_EXISTS error",
+			err:             fmt.Errorf("got error: ALREADY_EXISTS"),
+			expectedErrCode: util.ErrCodePtr(codes.AlreadyExists),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:

We saw unhappy cluster with error -

```
GRPC call: /csi.v1.Controller/CreateVolume, GRPC error: rpc error: code = Internal desc = googleapi: Error 409: Resource 'projects/...locations/us-east4-b/instances/...' already exists
```

Currently the `AlreadyExists` maps to Internal Error and hence results in SLO Violations. We are updating the mapping to `UserError`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
