### PR TITLE
fix(node): use MountSensitive to prevent SMB credential leaks on Windows

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -118,6 +118,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	fstype := "nfs"
 	// Mount options
 	options := []string{"bind"}
+	sensitiveOptions := []string{}
 	// Windows specific values (TODO: Revisit windows specific logic for bind mount)
 	if goOs == "windows" {
 		fstype = "cifs"
@@ -129,7 +130,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 
 		options = append(options, secrets[optionSmbUser])
-		options = append(options, secrets[optionSmbPassword])
+		sensitiveOptions = append(sensitiveOptions, secrets[optionSmbPassword])
 
 		//TODO: Remove this workaround after https://github.com/kubernetes/kubernetes/issues/75535
 		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
@@ -164,7 +165,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		options = append(options, mountOptions)
 	}
 
-	err = s.mounter.Mount(stagingTargetPath, targetPath, fstype, options)
+	if len(sensitiveOptions) > 0 {
+		err = s.mounter.MountSensitive(stagingTargetPath, targetPath, fstype, options, sensitiveOptions)
+	} else {
+		err = s.mounter.Mount(stagingTargetPath, targetPath, fstype, options)
+	}
 	if err != nil {
 		klog.Errorf("Mount %q failed on node %s, cleaning up", targetPath, s.driver.config.NodeName)
 		if unmntErr := mount.CleanupMountPoint(stagingTargetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR ensures that SMB credentials (passwords) are not leaked in plaintext within Windows node mount logs. 
We switch from using the standard `Mount` call to `MountSensitive` inside `pkg/csi_driver/node.go` when publishing volumes on Windows. This ensures that sensitive mount options (like the SMB password) are correctly masked in logs and pod events, even when logging verbosity is elevated (`-v=4` or higher).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
