### PR TITLE
Add Filestore Share Pools provisioning support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,9 +66,9 @@ var (
 	// Feature Filestore NFSv4, only take effect when feature-nfs-v4 is set to true.
 	featureNFSv4Support = flag.Bool("feature-nfs-v4", false, "if set to true, the Filestore CSI driver will support using the NFSv4 protocol for mounting Filestore instances.")
 
-	// Feature multishare backups enabled
 	featureMultishareBackups        = flag.Bool("feature-multishare-backups", false, "if set to true, the multishare backups will be enabled. enable-multishare must be set to true as well")
 	featureNFSExportOptionsOnCreate = flag.Bool("feature-nfs-export-options", false, "if set to true, the driver will accpet nfs-export-options-on-create parameter and configure IP Access rules")
+	featureSharePools               = flag.Bool("feature-share-pools", false, "if set to true, the driver will support Filestore Share Pools provisioning")
 
 	// Feature stateful CSI driver specific parameters
 	featureStateful      = flag.Bool("feature-stateful-multishare", false, "if set to true, the controller will run stateful multishare controller, if set to true, enable-multishare must be set to true as well")
@@ -210,6 +210,9 @@ func main() {
 		},
 		FeatureNFSv4Support: &driver.FeatureNFSv4Support{
 			Enabled: *featureNFSv4Support,
+		},
+		FeatureSharePools: &driver.FeatureSharePools{
+			Enabled: *featureSharePools,
 		},
 	}
 

--- a/pkg/cloud_provider/file/fake.go
+++ b/pkg/cloud_provider/file/fake.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
+	"strings"
 )
 
 const (
@@ -44,6 +45,7 @@ type fakeServiceManager struct {
 	createdMultishareInstance map[string]*MultishareInstance
 	createdMultishares        map[string]*Share
 	multishareops             []*filev1beta1multishare.Operation
+	allocatedShares           map[string]*PoolShare // key: requestId
 }
 
 var _ Service = &fakeServiceManager{}
@@ -54,6 +56,7 @@ func NewFakeService() (Service, error) {
 		backups:                   map[string]*Backup{},
 		createdMultishareInstance: make(map[string]*MultishareInstance),
 		createdMultishares:        make(map[string]*Share),
+		allocatedShares:           make(map[string]*PoolShare),
 	}, nil
 }
 
@@ -64,6 +67,7 @@ func NewFakeServiceForMultishare(instances []*MultishareInstance, shares []*Shar
 		createdMultishareInstance: make(map[string]*MultishareInstance),
 		createdMultishares:        make(map[string]*Share),
 		multishareops:             make([]*filev1beta1multishare.Operation, 0),
+		allocatedShares:           make(map[string]*PoolShare),
 	}
 
 	for _, instance := range instances {
@@ -528,4 +532,51 @@ func (manager *fakeBlockingServiceManager) IsOpDone(*filev1beta1multishare.Opera
 	}
 
 	return !val.ReportRunning, nil
+}
+
+func (manager *fakeServiceManager) AcquireShare(ctx context.Context, parentPool string, requestID string, capacityGb int64) (*PoolShare, error) {
+	if manager.allocatedShares == nil {
+		manager.allocatedShares = make(map[string]*PoolShare)
+	}
+	if share, exists := manager.allocatedShares[requestID]; exists {
+		return share, nil
+	}
+
+	if strings.Contains(parentPool, "exhausted") {
+		return nil, &googleapi.Error{
+			Code:    429,
+			Message: "no available shares in the pool",
+		}
+	}
+
+	uuidStr := uuid.New().String()
+	share := &PoolShare{
+		IpAddress: "10.1.1.1",
+		ShareId:   fmt.Sprintf("share-%s", uuidStr),
+	}
+	manager.allocatedShares[requestID] = share
+	return share, nil
+}
+
+func (manager *fakeServiceManager) ReleaseShare(ctx context.Context, poolName string, ipAddress string, shareID string) error {
+	if manager.allocatedShares == nil {
+		manager.allocatedShares = make(map[string]*PoolShare)
+	}
+
+	for token, share := range manager.allocatedShares {
+		if share.ShareId == shareID {
+			if share.IpAddress != ipAddress {
+				return fmt.Errorf("IP address mismatch: expected %q, got %q", share.IpAddress, ipAddress)
+			}
+			delete(manager.allocatedShares, token)
+			return nil
+		}
+	}
+	return &googleapi.Error{
+		Errors: []googleapi.ErrorItem{
+			{
+				Reason: "notFound",
+			},
+		},
+	}
 }

--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -17,6 +17,7 @@ limitations under the License.
 package file
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -75,6 +76,11 @@ type Share struct {
 	CapacityBytes    int64
 	BackupId         string
 	NfsExportOptions []*NfsExportOptions
+}
+
+type PoolShare struct {
+	IpAddress string
+	ShareId   string
 }
 
 type MultishareInstance struct {
@@ -193,9 +199,13 @@ type Service interface {
 	GetOp(ctx context.Context, op string) (*filev1beta1multishare.Operation, error)
 	IsOpDone(op *filev1beta1multishare.Operation) (bool, error)
 	ListOps(ctx context.Context, resource *ListFilter) ([]*filev1beta1multishare.Operation, error)
+	// Share pool ops
+	AcquireShare(ctx context.Context, parentPool string, requestID string, capacityGb int64) (*PoolShare, error)
+	ReleaseShare(ctx context.Context, poolName string, ipAddress string, shareID string) error
 }
 
 type gcfsServiceManager struct {
+	httpClient        *http.Client
 	fileService       *filev1beta1.Service
 	instancesService  *filev1beta1.ProjectsLocationsInstancesService
 	operationsService *filev1beta1.ProjectsLocationsOperationsService
@@ -269,6 +279,7 @@ func NewGCFSService(version string, client *http.Client, primaryFilestoreService
 	klog.Infof("Using endpoint %q for multishare filestore", fileMultishareService.BasePath)
 
 	return &gcfsServiceManager{
+		httpClient:                       client,
 		fileService:                      fileService,
 		instancesService:                 filev1beta1.NewProjectsLocationsInstancesService(fileService),
 		operationsService:                filev1beta1.NewProjectsLocationsOperationsService(fileService),
@@ -1468,4 +1479,86 @@ func extractNfsShareExportOptions(options []*NfsExportOptions) []*filev1beta1mul
 			})
 	}
 	return filerOpts
+}
+
+const (
+	betaBasePath = "v1beta1"
+)
+
+type AcquireShareRequest struct {
+	CapacityGb int64  `json:"capacityGb,string,omitempty"`
+	RequestId  string `json:"requestId,omitempty"`
+}
+
+type AcquireShareResponse struct {
+	IpAddress string `json:"ipAddress,omitempty"`
+	ShareId   string `json:"shareId,omitempty"`
+}
+
+type ReleaseShareRequest struct {
+	IpAddress string `json:"ipAddress,omitempty"`
+	ShareId   string `json:"shareId,omitempty"`
+}
+
+func (manager *gcfsServiceManager) doSharePoolRequest(ctx context.Context, apiMethod string, parentPool string, reqBody interface{}, respBody interface{}) error {
+	basePath := manager.fileService.BasePath
+	if !strings.HasSuffix(basePath, "/") {
+		basePath += "/"
+	}
+	url := fmt.Sprintf("%s%s/%s:%s", basePath, betaBasePath, parentPool, apiMethod)
+
+	jsonBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body for %s: %w", apiMethod, err)
+	}
+
+	// TODO: Update this to use the standard google-api-go-client library once Share Pools API client functions are officially supported.
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create http request for %s: %w", apiMethod, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := manager.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request for %s: %w", apiMethod, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return googleapi.CheckResponse(resp)
+	}
+
+	if respBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+			return fmt.Errorf("failed to decode response for %s: %w", apiMethod, err)
+		}
+	}
+	return nil
+}
+
+func (manager *gcfsServiceManager) AcquireShare(ctx context.Context, parentPool string, requestID string, capacityGb int64) (*PoolShare, error) {
+	reqBody := &AcquireShareRequest{
+		CapacityGb: capacityGb,
+		RequestId:  requestID,
+	}
+
+	var respBody AcquireShareResponse
+	if err := manager.doSharePoolRequest(ctx, "acquireShare", parentPool, reqBody, &respBody); err != nil {
+		return nil, err
+	}
+
+	return &PoolShare{
+		IpAddress: respBody.IpAddress,
+		ShareId:   respBody.ShareId,
+	}, nil
+}
+
+func (manager *gcfsServiceManager) ReleaseShare(ctx context.Context, poolName string, ipAddress string, shareID string) error {
+	reqBody := &ReleaseShareRequest{
+		IpAddress: ipAddress,
+		ShareId:   shareID,
+	}
+
+	return manager.doSharePoolRequest(ctx, "releaseShare", poolName, reqBody, nil)
 }

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -891,3 +891,158 @@ func TestIsUserError(t *testing.T) {
 		})
 	}
 }
+
+func TestAcquireShare(t *testing.T) {
+	parentPool := "projects/test-project/locations/us-central1/sharePools/test-pool"
+	reqID := "request-123"
+	capacityGb := int64(10)
+
+	tests := []struct {
+		name         string
+		responseCode int
+		responseBody interface{}
+		expectErr    bool
+		expected     *PoolShare
+	}{
+		{
+			name:         "successful acquire",
+			responseCode: http.StatusOK,
+			responseBody: &PoolShare{
+				IpAddress: "10.0.0.1",
+				ShareId:   "share-123",
+			},
+			expected: &PoolShare{
+				IpAddress: "10.0.0.1",
+				ShareId:   "share-123",
+			},
+		},
+		{
+			name:         "api error response",
+			responseCode: http.StatusBadRequest,
+			responseBody: map[string]string{"error": "invalid parent pool"},
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedPath := fmt.Sprintf("/v1beta1/%s:acquireShare", parentPool)
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected URL path %q, got %q", expectedPath, r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("expected method %s, got %s", http.MethodPost, r.Method)
+				}
+
+				var reqBody AcquireShareRequest
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				if reqBody.RequestId != reqID || reqBody.CapacityGb != capacityGb {
+					t.Errorf("unexpected request body fields: %+v", reqBody)
+				}
+
+				w.WriteHeader(tc.responseCode)
+				json.NewEncoder(w).Encode(tc.responseBody)
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			fileService, err := filev1beta1.NewService(ctx, option.WithHTTPClient(server.Client()))
+			if err != nil {
+				t.Fatalf("failed to create service client: %v", err)
+			}
+			fileService.BasePath = server.URL + "/"
+
+			manager := &gcfsServiceManager{
+				fileService: fileService,
+				httpClient:  server.Client(),
+			}
+
+			resp, err := manager.AcquireShare(ctx, parentPool, reqID, capacityGb)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.IpAddress != tc.expected.IpAddress || resp.ShareId != tc.expected.ShareId {
+				t.Errorf("expected parsed response %+v, got %+v", tc.expected, resp)
+			}
+		})
+	}
+}
+
+func TestReleaseShare(t *testing.T) {
+	parentPool := "projects/test-project/locations/us-central1/sharePools/test-pool"
+	shareID := "share-123"
+	ipAddr := "10.0.0.1"
+
+	tests := []struct {
+		name         string
+		responseCode int
+		expectErr    bool
+	}{
+		{
+			name:         "successful release",
+			responseCode: http.StatusOK,
+		},
+		{
+			name:         "api error response",
+			responseCode: http.StatusNotFound,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedPath := fmt.Sprintf("/v1beta1/%s:releaseShare", parentPool)
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected URL path %q, got %q", expectedPath, r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("expected method %s, got %s", http.MethodPost, r.Method)
+				}
+
+				var reqBody ReleaseShareRequest
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				if reqBody.ShareId != shareID || reqBody.IpAddress != ipAddr {
+					t.Errorf("unexpected request body fields: %+v", reqBody)
+				}
+
+				w.WriteHeader(tc.responseCode)
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			fileService, err := filev1beta1.NewService(ctx, option.WithHTTPClient(server.Client()))
+			if err != nil {
+				t.Fatalf("failed to create service client: %v", err)
+			}
+			fileService.BasePath = server.URL + "/"
+
+			manager := &gcfsServiceManager{
+				fileService: fileService,
+				httpClient:  server.Client(),
+			}
+
+			err = manager.ReleaseShare(ctx, parentPool, ipAddr, shareID)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -204,6 +204,14 @@ func (m *controllerServer) Run(stopCh <-chan struct{}) {
 
 // CreateVolume creates a GCFS instance
 func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	sharePoolPath := req.GetParameters()[paramKeySharePool]
+	if sharePoolPath != "" {
+		if s.config.features.FeatureSharePools == nil || !s.config.features.FeatureSharePools.Enabled {
+			return nil, status.Error(codes.FailedPrecondition, "cannot create share pool volume: Share Pools feature is disabled")
+		}
+		return s.handleCreateSharePoolVolume(ctx, req, sharePoolPath)
+	}
+
 	if strings.ToLower(req.GetParameters()[paramMultishare]) == "true" {
 		if s.config.multiShareController == nil {
 			return nil, status.Error(codes.InvalidArgument, "multishare controller not enabled")
@@ -425,6 +433,13 @@ func (s *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolu
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume id is empty")
+	}
+
+	if isSharePoolVolumeID(volumeID) {
+		if s.config.features.FeatureSharePools == nil || !s.config.features.FeatureSharePools.Enabled {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot delete share pool volume %q: Share Pools feature is disabled", volumeID)
+		}
+		return s.handleDeleteSharePoolVolume(ctx, req, volumeID)
 	}
 
 	if isMultishareVolId(volumeID) {
@@ -775,7 +790,7 @@ func (s *controllerServer) generateNewFileInstance(name string, capBytes int64, 
 				fileProtocol = v
 			}
 		case ParameterKeyLabels, ParameterKeyPVCName, ParameterKeyPVCNamespace, ParameterKeyPVName, paramMountOptions:
-		case "csiprovisionersecretname", "csiprovisionersecretnamespace":
+		case "csiprovisionersecretname", "csiprovisionersecretnamespace", paramKeySharePool:
 		default:
 			return nil, fmt.Errorf("invalid parameter %q", k)
 		}

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -104,6 +104,11 @@ type GCFSDriverFeatureOptions struct {
 	FeatureMultishareBackups        *FeatureMultishareBackups
 	FeatureNFSExportOptionsOnCreate *FeatureNFSExportOptionsOnCreate
 	FeatureNFSv4Support             *FeatureNFSv4Support
+	FeatureSharePools               *FeatureSharePools
+}
+
+type FeatureSharePools struct {
+	Enabled bool
 }
 
 type FeatureMultishareBackups struct {

--- a/pkg/csi_driver/sharepool.go
+++ b/pkg/csi_driver/sharepool.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/cloud_provider/file"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
+)
+
+const (
+	paramKeySharePool               = "share-pool"
+	defaultSharePoolShareCapacityGb = 1
+	sharePoolURLScheme              = "sharepool"
+	sharePoolURLPrefix              = sharePoolURLScheme + "://"
+)
+
+func buildSharePoolVolumeID(parentPool, shareID, ipAddress string) string {
+	// Scheme format: sharepool://{project}/{location}/{share_pool}/shares/{share_id}?ip={ip_address}
+	// parentPool format: projects/{project}/locations/{location}/sharePools/{share_pool}
+
+	hostPath := strings.Replace(parentPool, "projects/", sharePoolURLPrefix, 1)
+	hostPath = strings.Replace(hostPath, "/locations/", "/", 1)
+	hostPath = strings.Replace(hostPath, "/sharePools/", "/", 1)
+
+	return fmt.Sprintf("%s/shares/%s?ip=%s", hostPath, shareID, ipAddress)
+}
+
+func parseSharePoolVolumeID(volumeID string) (parent, shareID, ipAddress string, err error) {
+	parsedURL, err := url.Parse(volumeID)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	if parsedURL.Scheme != sharePoolURLScheme {
+		return "", "", "", fmt.Errorf("invalid volume ID scheme %q: expected %q", parsedURL.Scheme, sharePoolURLScheme)
+	}
+
+	// Extract project, location, pool name from Path segment
+	parts := strings.Split(strings.Trim(parsedURL.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "shares" {
+		return "", "", "", fmt.Errorf("invalid composite volume ID: %s", volumeID)
+	}
+
+	project := parsedURL.Host
+	location := parts[0]
+	poolName := parts[1]
+	shareID = parts[3]
+
+	parent = fmt.Sprintf("projects/%s/locations/%s/sharePools/%s", project, location, poolName)
+	ipAddress = parsedURL.Query().Get("ip")
+
+	return
+}
+
+func isSharePoolVolumeID(volumeID string) bool {
+	return strings.HasPrefix(volumeID, sharePoolURLPrefix)
+}
+
+func (s *controllerServer) handleCreateSharePoolVolume(ctx context.Context, req *csi.CreateVolumeRequest, sharePoolPath string) (*csi.CreateVolumeResponse, error) {
+	name := req.GetName()
+	if len(name) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "CreateVolume name must be provided")
+	}
+
+	if err := s.config.driver.validateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	capacityBytes := req.GetCapacityRange().GetRequiredBytes()
+	capacityGb := util.RoundBytesToGb(capacityBytes)
+	if capacityGb == 0 {
+		capacityGb = defaultSharePoolShareCapacityGb // Default to defaultSharePoolShareCapacityGb if not specified (capacityGb == 0)
+	}
+
+	klog.V(4).Infof("Acquiring Share Pool volume: pool %q, capacity %d GiB, requestID %q", sharePoolPath, capacityGb, name)
+	poolShare, err := s.config.fileService.AcquireShare(ctx, sharePoolPath, name, capacityGb)
+	if err != nil {
+		klog.Errorf("Failed to acquire share from pool %s: %v", sharePoolPath, err)
+		return nil, file.StatusError(err)
+	}
+
+	shareID := poolShare.ShareId
+
+	compositeVolumeID := buildSharePoolVolumeID(sharePoolPath, shareID, poolShare.IpAddress)
+
+	klog.Infof("Successfully acquired Share Pool volume: %q, Composite ID: %q, IP: %q, ShareId: %q", poolShare.ShareId, compositeVolumeID, poolShare.IpAddress, poolShare.ShareId)
+
+	protocol := req.GetParameters()[paramFileProtocol]
+	if protocol == "" {
+		protocol = v3FileProtocol
+	}
+
+	resp := &csi.CreateVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:      compositeVolumeID,
+			CapacityBytes: util.GbToBytes(capacityGb),
+			VolumeContext: map[string]string{
+				attrIP:           poolShare.IpAddress,
+				attrVolume:       poolShare.ShareId,
+				attrFileProtocol: protocol,
+			},
+		},
+	}
+
+	if mountOptions, ok := req.GetParameters()[paramMountOptions]; ok && mountOptions != "" {
+		resp.Volume.VolumeContext[attrMountOptions] = mountOptions
+	}
+	return resp, nil
+}
+
+func (s *controllerServer) handleDeleteSharePoolVolume(ctx context.Context, req *csi.DeleteVolumeRequest, volumeID string) (*csi.DeleteVolumeResponse, error) {
+	klog.V(4).Infof("Releasing Share Pool volume from composite ID: %q", volumeID)
+
+	parent, shareID, ipAddress, err := parseSharePoolVolumeID(volumeID)
+	if err != nil {
+		klog.Errorf("Failed to parse composite volume ID %q: %v", volumeID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse composite volume ID: %v", err)
+	}
+
+	klog.V(4).Infof("Parsed release parameters: parent=%q, shareID=%q, ipAddress=%q", parent, shareID, ipAddress)
+
+	err = s.config.fileService.ReleaseShare(ctx, parent, ipAddress, shareID)
+	if err != nil {
+		if file.IsNotFoundErr(err) {
+			klog.Warningf("Share Pool volume %q not found, returning success", volumeID)
+			return &csi.DeleteVolumeResponse{}, nil
+		}
+		klog.Errorf("Failed to release Share Pool volume %q: %v", volumeID, err)
+		return nil, file.StatusError(err)
+	}
+
+	klog.Infof("Successfully released Share Pool volume: %q", volumeID)
+	return &csi.DeleteVolumeResponse{}, nil
+}

--- a/pkg/csi_driver/sharepool_test.go
+++ b/pkg/csi_driver/sharepool_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"sigs.k8s.io/gcp-filestore-csi-driver/pkg/util"
+)
+
+func TestCreateVolume_SharePool(t *testing.T) {
+	ctx := context.Background()
+	sharePoolPath := "projects/test-project/locations/us-central1/sharePools/my-pool"
+	volumeCapabilities := []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		req                *csi.CreateVolumeRequest
+		featureEnabled     bool
+		expectErr          bool
+		expectDefaultBytes bool
+	}{
+		{
+			name: "successful allocation",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-sharepool-volume",
+				Parameters: map[string]string{
+					paramKeySharePool: sharePoolPath,
+				},
+				VolumeCapabilities: volumeCapabilities,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1 * util.Gb,
+				},
+			},
+			featureEnabled: true,
+		},
+		{
+			name: "omitted capacity defaulting",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-sharepool-default-cap",
+				Parameters: map[string]string{
+					paramKeySharePool: sharePoolPath,
+				},
+				VolumeCapabilities: volumeCapabilities,
+				CapacityRange:      nil,
+			},
+			featureEnabled:     true,
+			expectDefaultBytes: true,
+		},
+		{
+			name: "missing request name",
+			req: &csi.CreateVolumeRequest{
+				Name: "",
+				Parameters: map[string]string{
+					paramKeySharePool: sharePoolPath,
+				},
+				VolumeCapabilities: volumeCapabilities,
+			},
+			featureEnabled: true,
+			expectErr:      true,
+		},
+		{
+			name: "feature disabled",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-sharepool-volume",
+				Parameters: map[string]string{
+					paramKeySharePool: sharePoolPath,
+				},
+				VolumeCapabilities: volumeCapabilities,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1 * util.Gb,
+				},
+			},
+			featureEnabled: false,
+			expectErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := initTestController(t).(*controllerServer)
+			cs.config.features.FeatureSharePools = &FeatureSharePools{Enabled: tc.featureEnabled}
+
+			resp, err := cs.CreateVolume(ctx, tc.req)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CreateVolume failed: %v", err)
+			}
+			if resp == nil || resp.Volume == nil {
+				t.Fatalf("expected non-nil volume response")
+			}
+			if !strings.HasPrefix(resp.Volume.VolumeId, sharePoolURLPrefix) || !strings.Contains(resp.Volume.VolumeId, "/shares/") {
+				t.Errorf("VolumeId = %q, want prefix %q and '/shares/'", resp.Volume.VolumeId, sharePoolURLPrefix)
+			}
+			if got, want := resp.Volume.VolumeContext[attrIP], "10.1.1.1"; got != want {
+				t.Errorf("VolumeContext[%s] = %q, want %q", attrIP, got, want)
+			}
+			if got := resp.Volume.VolumeContext[attrVolume]; !strings.HasPrefix(got, "share-") {
+				t.Errorf("VolumeContext[%s] = %q, want prefix 'share-'", attrVolume, got)
+			}
+			if tc.expectDefaultBytes {
+				expectedDefaultBytes := util.GbToBytes(defaultSharePoolShareCapacityGb)
+				if got, want := resp.Volume.CapacityBytes, expectedDefaultBytes; got != want {
+					t.Errorf("CapacityBytes = %d, want %d", got, want)
+				}
+			}
+
+			if tc.name == "successful allocation" {
+				// Test idempotency/retry
+				respRetry, err := cs.CreateVolume(ctx, tc.req)
+				if err != nil {
+					t.Fatalf("CreateVolume retry failed: %v", err)
+				}
+				if got, want := respRetry.Volume.VolumeId, resp.Volume.VolumeId; got != want {
+					t.Errorf("VolumeId on retry = %q, want %q", got, want)
+				}
+				if got, want := respRetry.Volume.VolumeContext[attrVolume], resp.Volume.VolumeContext[attrVolume]; got != want {
+					t.Errorf("VolumeContext[%s] on retry = %q, want %q", attrVolume, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteVolume_SharePool(t *testing.T) {
+	ctx := context.Background()
+	sharePoolPath := "projects/test-project/locations/us-central1/sharePools/my-pool"
+	volumeCapabilities := []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		volumeIDFunc   func(allocatedID string) string
+		featureEnabled bool
+		expectErr      bool
+		runDouble      bool
+	}{
+		{
+			name:           "successful deletion",
+			volumeIDFunc:   func(allocatedID string) string { return allocatedID },
+			featureEnabled: true,
+		},
+		{
+			name:           "idempotent delete",
+			volumeIDFunc:   func(allocatedID string) string { return allocatedID },
+			featureEnabled: true,
+			runDouble:      true,
+		},
+		{
+			name:           "invalid malformed volume ID",
+			volumeIDFunc:   func(allocatedID string) string { return sharePoolURLPrefix + "test-project/us-central1/my-pool/shares" },
+			featureEnabled: true,
+			expectErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := initTestController(t).(*controllerServer)
+			cs.config.features.FeatureSharePools = &FeatureSharePools{Enabled: tc.featureEnabled}
+
+			// Allocate a volume first
+			createReq := &csi.CreateVolumeRequest{
+				Name: "test-sharepool-volume",
+				Parameters: map[string]string{
+					paramKeySharePool: sharePoolPath,
+				},
+				VolumeCapabilities: volumeCapabilities,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1 * util.Gb,
+				},
+			}
+			resp, err := cs.CreateVolume(ctx, createReq)
+			if err != nil {
+				t.Fatalf("CreateVolume failed: %v", err)
+			}
+
+			targetVolumeID := tc.volumeIDFunc(resp.Volume.VolumeId)
+			delReq := &csi.DeleteVolumeRequest{
+				VolumeId: targetVolumeID,
+			}
+
+			_, err = cs.DeleteVolume(ctx, delReq)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DeleteVolume failed: %v", err)
+			}
+
+			if tc.runDouble {
+				_, err = cs.DeleteVolume(ctx, delReq)
+				if err != nil {
+					t.Errorf("DeleteVolume retry failed: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR introduces support for **Filestore Share Pools** dynamic volume provisioning and deletion inside the GCP Filestore CSI Driver:

* **Share Pools Provisioning Handler**: Adds handleCreateSharePoolVolume and handleDeleteSharePoolVolume in the controller manager (pkg/csi_driver/controller.go) to detect and route volume requests referencing the sharepool StorageClass parameter.
* **GCFS Client Wrapper**: Integrates the official ProjectsLocationsSharePoolsService API clients inside pkg/cloud_provider/file/file.go to handle AcquireShare and ReleaseShare service calls.
* **Composite VolumeID Contracts**: Establishes sharepool://{project}/{location}/{share_pool}/shares/{uuid}?ip={ip_address} as the standardized composite VolumeID schema for tracking and releasing provisioned shares.
* **Unit Testing**: Introduces comprehensive tests in pkg/csi_driver/controller_test.go covering success cases, idempotent retries, defaulting capacity behaviors, and malformed VolumeID validation checks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
* **Direct REST calls**: This PR uses http client instead of standard go client because the updated  API client library version with filestore sharepool support has not yet been officially released on the public internet. This should be updated once the library is published.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Releases share pool based fast provisioning/de-provisioning of volume.
```
