### PR TITLE
Add official go client for sharepool APIs

### DIFF
--- a/examples/kubernetes/sharepool/pod.yaml
+++ b/examples/kubernetes/sharepool/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sharepool-test-pod
+spec:
+  containers:
+  - name: test-container
+    image: busybox
+    command: ["/bin/sh", "-c"]
+    args: ["echo 'Hello from SharePool!' > /mnt/test.txt && sleep 3600"]
+    volumeMounts:
+    - mountPath: /mnt
+      name: sharepool-vol
+  volumes:
+  - name: sharepool-vol
+    persistentVolumeClaim:
+      claimName: sharepool-pvc

--- a/examples/kubernetes/sharepool/pvc.yaml
+++ b/examples/kubernetes/sharepool/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sharepool-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: staging-share-pool-sc
+  resources:
+    requests:
+      storage: 10Gi

--- a/examples/kubernetes/sharepool/storageclass.yaml
+++ b/examples/kubernetes/sharepool/storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: staging-share-pool-sc
+provisioner: filestore.csi.storage.gke.io
+parameters:
+  share-pool: "projects/demo-project/locations/us-central1/sharePools/demo-pool-1"

--- a/pkg/cloud_provider/file/file.go
+++ b/pkg/cloud_provider/file/file.go
@@ -17,7 +17,6 @@ limitations under the License.
 package file
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1481,70 +1480,17 @@ func extractNfsShareExportOptions(options []*NfsExportOptions) []*filev1beta1mul
 	return filerOpts
 }
 
-const (
-	betaBasePath = "v1beta1"
-)
 
-type AcquireShareRequest struct {
-	CapacityGb int64  `json:"capacityGb,string,omitempty"`
-	RequestId  string `json:"requestId,omitempty"`
-}
-
-type AcquireShareResponse struct {
-	IpAddress string `json:"ipAddress,omitempty"`
-	ShareId   string `json:"shareId,omitempty"`
-}
-
-type ReleaseShareRequest struct {
-	IpAddress string `json:"ipAddress,omitempty"`
-	ShareId   string `json:"shareId,omitempty"`
-}
-
-func (manager *gcfsServiceManager) doSharePoolRequest(ctx context.Context, apiMethod string, parentPool string, reqBody interface{}, respBody interface{}) error {
-	basePath := manager.fileService.BasePath
-	if !strings.HasSuffix(basePath, "/") {
-		basePath += "/"
-	}
-	url := fmt.Sprintf("%s%s/%s:%s", basePath, betaBasePath, parentPool, apiMethod)
-
-	jsonBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request body for %s: %w", apiMethod, err)
-	}
-
-	// TODO: Update this to use the standard google-api-go-client library once Share Pools API client functions are officially supported.
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return fmt.Errorf("failed to create http request for %s: %w", apiMethod, err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := manager.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send request for %s: %w", apiMethod, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return googleapi.CheckResponse(resp)
-	}
-
-	if respBody != nil {
-		if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
-			return fmt.Errorf("failed to decode response for %s: %w", apiMethod, err)
-		}
-	}
-	return nil
-}
 
 func (manager *gcfsServiceManager) AcquireShare(ctx context.Context, parentPool string, requestID string, capacityGb int64) (*PoolShare, error) {
-	reqBody := &AcquireShareRequest{
+	reqBody := &filev1beta1.AcquireShareRequest{
 		CapacityGb: capacityGb,
 		RequestId:  requestID,
 	}
 
-	var respBody AcquireShareResponse
-	if err := manager.doSharePoolRequest(ctx, "acquireShare", parentPool, reqBody, &respBody); err != nil {
+	call := manager.fileService.Projects.Locations.SharePools.AcquireShare(parentPool, reqBody)
+	respBody, err := call.Context(ctx).Do()
+	if err != nil {
 		return nil, err
 	}
 
@@ -1555,10 +1501,12 @@ func (manager *gcfsServiceManager) AcquireShare(ctx context.Context, parentPool 
 }
 
 func (manager *gcfsServiceManager) ReleaseShare(ctx context.Context, poolName string, ipAddress string, shareID string) error {
-	reqBody := &ReleaseShareRequest{
+	reqBody := &filev1beta1.ReleaseShareRequest{
 		IpAddress: ipAddress,
 		ShareId:   shareID,
 	}
 
-	return manager.doSharePoolRequest(ctx, "releaseShare", poolName, reqBody, nil)
+	call := manager.fileService.Projects.Locations.SharePools.ReleaseShare(poolName, reqBody)
+	_, err := call.Context(ctx).Do()
+	return err
 }

--- a/pkg/cloud_provider/file/file_test.go
+++ b/pkg/cloud_provider/file/file_test.go
@@ -935,7 +935,7 @@ func TestAcquireShare(t *testing.T) {
 					t.Errorf("expected method %s, got %s", http.MethodPost, r.Method)
 				}
 
-				var reqBody AcquireShareRequest
+				var reqBody filev1beta1.AcquireShareRequest
 				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 					t.Errorf("failed to decode request body: %v", err)
 				}
@@ -1009,7 +1009,7 @@ func TestReleaseShare(t *testing.T) {
 					t.Errorf("expected method %s, got %s", http.MethodPost, r.Method)
 				}
 
-				var reqBody ReleaseShareRequest
+				var reqBody filev1beta1.ReleaseShareRequest
 				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 					t.Errorf("failed to decode request body: %v", err)
 				}
@@ -1018,6 +1018,7 @@ func TestReleaseShare(t *testing.T) {
 				}
 
 				w.WriteHeader(tc.responseCode)
+				w.Write([]byte("{}"))
 			}))
 			defer server.Close()
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -557,6 +557,10 @@ func (s *controllerServer) ControllerModifyVolume(ctx context.Context, req *csi.
 		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
 	}
 
+	if isSharePoolVolumeID(volumeID) {
+		return nil, status.Error(codes.InvalidArgument, "ControllerModifyVolume is not supported for sharepool volumes")
+	}
+
 	params := req.GetMutableParameters()
 	// If no params (or empty), return success (no-op)
 	if len(params) == 0 {
@@ -880,6 +884,10 @@ func (s *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 		return nil, status.Error(codes.InvalidArgument, "ControllerExpandVolume volume ID must be provided")
 	}
 
+	if isSharePoolVolumeID(volumeID) {
+		return nil, status.Error(codes.InvalidArgument, "ControllerExpandVolume is not supported for sharepool volumes")
+	}
+
 	if isMultishareVolId(volumeID) {
 		if s.config.multiShareController == nil {
 			return nil, status.Error(codes.InvalidArgument, "multishare controller not enabled")
@@ -1099,6 +1107,11 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "CreateSnapshot source volume ID must be provided")
 	}
+
+	if isSharePoolVolumeID(volumeID) {
+		return nil, status.Error(codes.InvalidArgument, "CreateSnapshot is not supported for sharepool volumes")
+	}
+
 	if isMultishareVolId(volumeID) {
 		if s.config.multiShareController == nil {
 			return nil, status.Error(codes.InvalidArgument, "multishare controller not enabled")

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -1015,6 +1015,7 @@ func TestControllerExpandVolume(t *testing.T) {
 		currentSize int64
 		requiredCap int64
 		tier        string
+		volumeID    string
 		shouldError bool
 	}
 
@@ -1089,6 +1090,11 @@ func TestControllerExpandVolume(t *testing.T) {
 			tier:        regionalTier,
 			shouldError: true,
 		},
+		{
+			name:        "expand sharepool volume is not supported",
+			volumeID:    "sharepool://demo-project/us-central1/demo-pool-1/shares/share1",
+			shouldError: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1125,12 +1131,15 @@ func TestControllerExpandVolume(t *testing.T) {
 				tagManager:  cloud.NewFakeTagManager(),
 			})
 
-			// Create volumeID from instance
-			volumeID := getVolumeIDFromFileInstance(&file.ServiceInstance{
-				Name:     instanceName,
-				Location: testZone,
-				Volume:   file.Volume{Name: newInstanceVolume},
-			}, modeInstance)
+			// Create volumeID from instance if not explicitly provided
+			volumeID := tc.volumeID
+			if volumeID == "" {
+				volumeID = getVolumeIDFromFileInstance(&file.ServiceInstance{
+					Name:     instanceName,
+					Location: testZone,
+					Volume:   file.Volume{Name: newInstanceVolume},
+				}, modeInstance)
+			}
 
 			// Call ControllerExpandVolume
 			req := &csi.ControllerExpandVolumeRequest{
@@ -2388,6 +2397,14 @@ func TestCreateSnapshot(t *testing.T) {
 	}{
 		// Failure test cases
 		{
+			name: "Share pool volume is not supported",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "sharepool://demo-project/us-central1/demo-pool-1/shares/share1",
+				Name:           backupName,
+			},
+			expectErr: true,
+		},
+		{
 			name: "Existing backup found, with different volume Id (source zonal filestore instance), error expected",
 			req: &csi.CreateSnapshotRequest{
 				SourceVolumeId: modeInstance + "/" + zone + "/" + "myinstance1" + "/" + shareName,
@@ -3336,5 +3353,23 @@ func TestExtractBackupLabels(t *testing.T) {
 		if !reflect.DeepEqual(test.expectLabels, labels) {
 			t.Errorf("extractBackupLabels(): %s: got: %v, want: %v", test.name, labels, test.expectLabels)
 		}
+	}
+}
+
+func TestControllerModifyVolume_SharePoolNotSupported(t *testing.T) {
+	ctrl := initTestController(t)
+	req := &csi.ControllerModifyVolumeRequest{
+		VolumeId: "sharepool://demo-project/us-central1/demo-pool-1/shares/share1",
+	}
+	resp, err := ctrl.ControllerModifyVolume(context.Background(), req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got: %v", resp)
+	}
+	if err == nil {
+		t.Fatalf("expected error for sharepool volume id, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got: %v", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
* Use official go client for new sharepool APIs instead of using https calls as the official go clients now expose the filestore sharepool APIs.
* Some checks related to sharepool unsupported operations are also added.
* An example to use sharepool is also added.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
