### PR TITLE
Add defensive rpc.statd verification, liveness probes, and writable /run mounts

### DIFF
--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -63,6 +63,17 @@ spec:
         - name: nfs-services
           image: registry.k8s.io/cloud-provider-gcp/gcp-filestore-csi-driver
           command: ["/nfs_services_start.sh"]
+          volumeMounts:
+            - mountPath: /run
+              name: rpc-run-dir
+          livenessProbe:
+            exec:
+              command: ["rpcinfo", "-T", "udp", "127.0.0.1", "100024"]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command: ["rpcinfo", "-p", "127.0.0.1"]
       volumes:
         - name: registration-dir
           hostPath:
@@ -76,3 +87,5 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/filestore.csi.storage.gke.io/
             type: DirectoryOrCreate
+        - name: rpc-run-dir
+          emptyDir: {}

--- a/deploy/kubernetes/manifests/node.yaml
+++ b/deploy/kubernetes/manifests/node.yaml
@@ -59,6 +59,17 @@ spec:
           # Modify this image for local development with master branch.
           image: gcr.io/gke-release/gcp-filestore-csi-driver:v0.2.0-gke.0
           command: ["/nfs_services_start.sh"]
+          volumeMounts:
+            - mountPath: /run
+              name: rpc-run-dir
+          livenessProbe:
+            exec:
+              command: ["rpcinfo", "-T", "udp", "127.0.0.1", "100024"]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command: ["rpcinfo", "-p", "127.0.0.1"]
       volumes:
         - name: registration-dir
           hostPath:
@@ -72,3 +83,5 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/filestore.csi.storage.gke.io/
             type: DirectoryOrCreate
+        - name: rpc-run-dir
+          emptyDir: {}

--- a/deploy/kubernetes/nfs_services_start.sh
+++ b/deploy/kubernetes/nfs_services_start.sh
@@ -3,7 +3,11 @@
 set -o errexit
 trap "exit 0" TERM
 
-# 1. Start rpcbind safely (don't fail errexit if port 111 is already bound)
+# 1. Recreate paths shadowed by the Kubernetes emptyDir mount over /run
+mkdir -p /run/sendsigs.omit.d
+mkdir -p /run/rpc_pipefs
+
+# 2. Start rpcbind safely (don't fail errexit if port 111 is already bound)
 if ! rpcinfo -p 127.0.0.1 >/dev/null 2>&1; then
   service rpcbind start || echo "rpcbind start returned non-zero, continuing..."
 fi

--- a/deploy/kubernetes/nfs_services_start.sh
+++ b/deploy/kubernetes/nfs_services_start.sh
@@ -1,23 +1,50 @@
 #!/bin/sh
 
 set -o errexit
+trap "exit 0" TERM
 
-trap "{ exit 0; }" TERM
-
-service rpcbind start
-
-# If statd is already running, for example becuase of an existing nfs mount, we will fail
-# to service nfs-common start. If we successfully query the statd service (rpc program
-# number 100024), that means it's running, and we don't need to start it. This command
-# is put in /etc/default/nfs-common as the NEED_STATD variable must be set there.
-
-if rpcinfo -T udp 127.0.0.1 100024; then
-  echo statd already running
-  echo NEED_STATD=no >> /etc/default/nfs-common
-else
-  echo no statd found
+# 1. Start rpcbind safely (don't fail errexit if port 111 is already bound)
+if ! rpcinfo -p 127.0.0.1 >/dev/null 2>&1; then
+  service rpcbind start || echo "rpcbind start returned non-zero, continuing..."
 fi
 
-service nfs-common start  
+# 2. Check if statd is already registered (existing node mount)
+if rpcinfo -T udp 127.0.0.1 100024 >/dev/null 2>&1; then
+  echo "statd already running on host"
+  sed -i '/NEED_STATD/d' /etc/default/nfs-common 2>/dev/null || true
+  echo "NEED_STATD=no" >> /etc/default/nfs-common
+else
+  echo "no statd found, proceeding with start"
+  sed -i '/NEED_STATD/d' /etc/default/nfs-common 2>/dev/null || true
+  echo "NEED_STATD=yes" >> /etc/default/nfs-common
+fi
 
+# 3. Attempt to start the service normally
+service nfs-common start
+
+# 4. Verification Loop
+MAX_RETRIES=5
+COUNT=0
+until rpcinfo -T udp 127.0.0.1 100024 >/dev/null 2>&1; do
+  COUNT=$((COUNT + 1))
+  if [ "$COUNT" -ge "$MAX_RETRIES" ]; then
+    echo "--- DIAGNOSTIC FAILURE ---" >&2
+    echo "statd failed to register after $MAX_RETRIES attempts." >&2
+    echo "Attempting to launch statd in foreground for debug logs..." >&2
+    
+    # Kill any zombie background process that might be hanging
+    pkill rpc.statd 2>/dev/null || true
+    
+    # Launch in foreground: -F (foreground), -d (debug/stderr)
+    # This will block and stream logs until it crashes or is killed by K8s
+    /sbin/rpc.statd -F -d
+    
+    # If the foreground process somehow exits, exit the container to trigger a restart
+    exit 1
+  fi
+  echo "Waiting for statd registration (attempt $COUNT/$MAX_RETRIES)..."
+  sleep 2
+done
+
+echo "statd is healthy and registered."
 sleep infinity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
This heavily stabilizes the `nfs-services` container against a known race condition where crashed or zombie `rpc.statd` daemons silently block successful NFS GCE Filestore volume mounting. 

Previously, if `statd` failed to launch or became orphaned by a network reset, the container's primary bash loop (`sleep infinity`) would remain fully active. Kubelet would blindly view the pod as "Running" forever despite NFS locking being completely crippled on the underlying node.

This PR introduces comprehensive diagnostic and self-healing infrastructure:
1. **Writable `/run` volume override (`emptyDir`)**: The K8s Node container executes with strict security profiles (`readOnlyRootFilesystem: true`). An `emptyDir` mount (`rpc-run-dir`) was added over `/run` to guarantee `statd` dynamically possesses write-permissions for resolving local PID states and lockfiles.
2. **Defensive `/run` Re-Mapping (`nfs_services_start.sh`)**: Because the `emptyDir` intentionally eclipses the pre-compiled Docker directories, we inject `mkdir -p` commands at boot to recreate `/run/sendsigs.omit.d` and `/run/rpc_pipefs` so the Debian SysVinit handlers (like `rpcbind`) boot up silently and cleanly. 
3. **Rigorous Verification Loop (`nfs_services_start.sh`)**: The script now actively queries `rpcinfo` for 5 retries. If port 100024 fails to bind, the script purposefully executes `/sbin/rpc.statd -F -d` in the foreground to stream critical debug crashes directly to Cloud Logging, before executing an intentional container exit (`exit 1`) for node restarting.
4. **Liveness & Readiness Probes (`node.yaml`)**: The Kubelet has been configured to actively ping both port `111` (rpcbind) and port `100024` (statd). If either mapping dies across 3 consecutive 15-second cycles, Kubernetes detects the zombie state and successfully destroys/refreshes the sidecar.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes b/398437622

**Special notes for your reviewer**:
*Important manual mitigation for currently degraded clusters:*
Because the previous implementation lacked these probes and utilized `hostNetwork: true`, it's possible that degraded nodes currently have completely zombified `rpc.statd` processes permanently gripping port `100024` on the host OS itself. Because the host port is blocked, the newly rolled-out container will fail to bind it. 
To clear this state when rolling out this fix on severely degraded environments, cluster operators must manually execute `pkill rpc.statd` on the physical K8s node via SSH, or simply perform a physical rolling machine reboot of the impacted Linux node instances.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a critical issue where zombie NFS `rpc.statd` processes would permanently block successful Filestore volume mounts. Added a writable `rpc-run-dir` mount for stable locking and active Kubelet liveness/readiness probes to natively detect and restart corrupted NFS services.
```