### PR TITLE
test: update e2e base image to debian-12

### DIFF
--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -85,7 +85,7 @@ func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 		return fmt.Errorf("Failed to create firewall rule: %v", err)
 	}
 
-	imageURL := "projects/debian-cloud/global/images/family/debian-11"
+	imageURL := "projects/debian-cloud/global/images/family/debian-12"
 	inst := &compute.Instance{
 		Name:        i.name,
 		MachineType: machineType(i.zone, ""),


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Updates the hardcoded E2E test image from `debian-11` to `debian-12` in `test/remote/instance.go`. 

Google Cloud recently deprecated and removed the `debian-11` public image family alias from the `debian-cloud` project. Because this was hardcoded in the E2E test setup, it is currently throwing a `404 Not Found` API error during VM provisioning and failing E2E tests for all PRs targeting this branch. Bumping to `debian-12` restores the test infrastructure.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This fix is targeted at the `release-1.14` branch to unblock several automated cherry-pick PRs that are currently failing CI due to this 404 error. 

*(Note: If `master` has not yet been bumped to debian-12, this will likely need to be applied there as well!)*

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```