### PR TITLE
Merge pull request #1366 from arokade-dev/feature/substrate-envoy-mtl…

### DIFF
--- a/deploy/kubernetes/overlays/substrate/README.md
+++ b/deploy/kubernetes/overlays/substrate/README.md
@@ -9,9 +9,9 @@ This overlay enables the **GCP Filestore CSI Driver** to integrate natively with
 | Component | Manifest File | Rationale |
 | :--- | :--- | :--- |
 | **GKE Workload Identity** | `serviceaccount_patch.yaml` | Annotates `gcp-filestore-csi-controller-sa` with the GCP Service Account (`iam.gke.io/gcp-service-account`), eliminating static JSON key secrets. |
-| **Controller Patch** | `controller_patch.yaml` | 1. Sets `hostNetwork: false` so Workload Identity metadata server requests (`169.254.169.254`) succeed.<br>2. Deploys a privileged `socat` proxy bridging TCP port `10000` to Unix domain socket `/csi/csi.sock`.<br>3. Adds label `role: controller-plugin`.<br>4. Enables `--feature-volume-pools=true`. |
+| **Controller Patch** | `controller_patch.yaml` | 1. Sets `hostNetwork: false` so Workload Identity metadata server requests (`169.254.169.254`) succeed.<br>2. Deploys a privileged `envoy` mTLS proxy bridging TCP port `10000` to Unix domain socket `/csi/csi.sock`.<br>3. Adds label `role: controller-plugin`.<br>4. Enables `--feature-volume-pools=true`. |
 | **Node DaemonSet Patch** | `node_patch.yaml` | 1. Adds label `role: node-plugin`.<br>2. Mounts `/var/lib/ateom-gvisor` with `mountPropagation: Bidirectional` so NFS mounts are accessible by Substrate `ateom-gvisor`. |
-| **gRPC Controller Service** | `service.yaml` | Creates `Service/csi-filestore-controller` (port `50053` -> targetPort `10000`) selecting `app=gcp-filestore-csi-driver` and `role=controller-plugin`, guaranteeing traffic reaches only the controller. |
+| **gRPC Controller Service** | `service.yaml` | Creates `Service/csi-filestore-controller` (port `10000` -> targetPort `10000` over mTLS) selecting `app=gcp-filestore-csi-driver` and `role=controller-plugin`, guaranteeing traffic reaches only the controller. |
 | **Substrate Driver Config** | `csi_driver_config.yaml` | Registers the driver (`ate.dev/v1alpha1`) with Substrate pointing to the internal cluster DNS gRPC endpoint. |
 
 ---

--- a/deploy/kubernetes/overlays/substrate/controller_patch.yaml
+++ b/deploy/kubernetes/overlays/substrate/controller_patch.yaml
@@ -9,10 +9,10 @@
 #    - Differentiates controller pods from node daemonset pods so the csi-filestore-controller
 #      Kubernetes Service only routes gRPC control-plane traffic to this controller.
 #
-# 3. socat sidecar container (TCP port 10000 -> Unix socket /csi/csi.sock)
-#    - Substrate's ate-controller communicates with CSI drivers over gRPC network sockets.
-#      Because the CSI driver natively listens on a local Unix domain socket, this lightweight
-#      socat proxy exposes the Unix socket over TCP port 10000 inside the pod.
+# 3. envoy mTLS proxy sidecar container (TCP port 10000 -> Unix socket /csi/csi.sock)
+#    - Substrate's ate-api-server communicates with CSI drivers over mTLS gRPC network sockets.
+#      Because the CSI driver natively listens on a local Unix domain socket, this Envoy 
+#      proxy intercepts mTLS traffic on TCP port 10000 and forwards it to the Unix socket.
 #
 # 4. --feature-volume-pools=true
 #    - Enables VolumePool capacity management and volume claim/provisioning logic.
@@ -39,18 +39,44 @@ spec:
       volumes:
       - name: cloud-sa-volume
         $patch: delete
+      - name: envoy-config
+        configMap:
+          name: csi-envoy-config
+      - name: servicedns-certs
+        projected:
+          sources:
+          - podCertificate:
+              signerName: servicedns.podcert.ate.dev/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem
+      - name: podidentity-ca
+        projected:
+          sources:
+          - clusterTrustBundle:
+              signerName: podidentity.podcert.ate.dev/identity
+              labelSelector:
+                matchLabels:
+                  podcert.ate.dev/canarying: live
+              path: trust-bundle.pem
       containers:
-      # socat sidecar bridges TCP port 10000 to the local Unix CSI domain socket for Substrate gRPC control plane
-      - name: socat
-        image: docker.io/alpine/socat:1.7.4.3-r0
-        args:
-        - "tcp-listen:10000,fork,reuseaddr"
-        - "unix-connect:/var/lib/csi/sockets/pluginproxy/csi.sock"
+      # envoy mTLS proxy sidecar intercepts traffic on port 10000 to the local Unix CSI domain socket for Substrate control plane
+      - name: envoy
+        image: envoyproxy/envoy:v1.34-latest
+        command: ["/usr/local/bin/envoy"]
+        args: ["-c", "/etc/envoy/envoy.yaml"]
         securityContext:
           privileged: true
         volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy
         - name: socket-dir
-          mountPath: /var/lib/csi/sockets/pluginproxy
+          mountPath: /csi
+        - name: servicedns-certs
+          mountPath: /run/servicedns
+          readOnly: true
+        - name: podidentity-ca
+          mountPath: /run/podidentity-ca
+          readOnly: true
       - name: gcp-filestore-driver
         volumeMounts:
         # Explicitly retain socket-dir mount for CSI operations

--- a/deploy/kubernetes/overlays/substrate/csi_driver_config.yaml
+++ b/deploy/kubernetes/overlays/substrate/csi_driver_config.yaml
@@ -4,8 +4,8 @@
 # 1. driverName: filestore.csi.storage.gke.io
 #    - Matches the provisioner and CSI driver name used by GCP Filestore CSI Driver.
 #
-# 2. controllerEndpoint: dns:///csi-filestore-controller.gcp-filestore-csi-driver.svc.cluster.local:50053
-#    - Informs Substrate ate-controller how to reach the Filestore CSI controller gRPC endpoint
+# 2. controllerEndpoint: tcp://csi-filestore-controller.gcp-filestore-csi-driver.svc:10000
+#    - Informs Substrate ate-api-server how to reach the Filestore CSI controller mTLS endpoint
 #      via internal cluster DNS.
 #
 # 3. nodeSocketOverride: unix:///var/lib/kubelet/plugins/filestore.csi.storage.gke.io/csi.sock
@@ -19,5 +19,9 @@ metadata:
   name: filestore.csi.storage.gke.io
 spec:
   driverName: filestore.csi.storage.gke.io
-  controllerEndpoint: dns:///csi-filestore-controller.gcp-filestore-csi-driver.svc.cluster.local:50053
+  controllerEndpoint: tcp://csi-filestore-controller.gcp-filestore-csi-driver.svc:10000
   nodeSocketOverride: unix:///var/lib/kubelet/plugins/filestore.csi.storage.gke.io/csi.sock
+  tls:
+    enabled: true
+    usePodIdentity: true
+    serverName: csi-filestore-controller.gcp-filestore-csi-driver.svc

--- a/deploy/kubernetes/overlays/substrate/envoy_configmap.yaml
+++ b/deploy/kubernetes/overlays/substrate/envoy_configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csi-envoy-config
+  namespace: gcp-filestore-csi-driver
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 15000 }
+    static_resources:
+      listeners:
+      - name: csi_tls_listener
+        address:
+          socket_address: { address: 0.0.0.0, port_value: 10000 }
+        filter_chains:
+        - transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              require_client_certificate: true
+              common_tls_context:
+                alpn_protocols:
+                - h2
+                tls_certificates:
+                - certificate_chain: { filename: /run/servicedns/credential-bundle.pem }
+                  private_key: { filename: /run/servicedns/credential-bundle.pem }
+                watched_directory: { path: /run/servicedns }
+                validation_context:
+                  trusted_ca: { filename: /run/podidentity-ca/trust-bundle.pem }
+                  watched_directory: { path: /run/podidentity-ca }
+                  match_typed_subject_alt_names:
+                  - san_type: URI
+                    matcher:
+                      # Pin to authorized Substrate API server identity
+                      exact: "spiffe://cluster.local/ns/ate-system/sa/ate-api-server"
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: csi_proxy
+              cluster: csi_unix_socket
+      clusters:
+      - name: csi_unix_socket
+        connect_timeout: 0.25s
+        type: STATIC
+        load_assignment:
+          cluster_name: csi_unix_socket
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  pipe:
+                    path: /csi/csi.sock

--- a/deploy/kubernetes/overlays/substrate/kustomization.yaml
+++ b/deploy/kubernetes/overlays/substrate/kustomization.yaml
@@ -13,7 +13,8 @@
 # - Base upstream CSI Driver deployment (../stable-master)
 # - gRPC ClusterIP Service for Substrate control-plane connectivity (service.yaml)
 # - Substrate CSIDriverConfig registration CR (csi_driver_config.yaml)
-# - Controller Workload Identity, role label, and socat proxy patch (controller_patch.yaml)
+# - Envoy configuration map (envoy_configmap.yaml)
+# - Controller Workload Identity, role label, and envoy mTLS proxy patch (controller_patch.yaml)
 # - Node DaemonSet role label and bidirectional mount propagation patch (node_patch.yaml)
 # - ServiceAccount Workload Identity annotation patch (serviceaccount_patch.yaml)
 
@@ -23,6 +24,7 @@ resources:
 - ../stable-master
 - service.yaml
 - csi_driver_config.yaml
+- envoy_configmap.yaml
 patches:
 - path: controller_patch.yaml
 - path: node_patch.yaml
@@ -31,5 +33,5 @@ namespace: gcp-filestore-csi-driver
 
 images:
 - name: registry.k8s.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  newName: gcr.io/gke-release/gcp-filestore-csi-driver
-  digest: sha256:9bde4b2e81e914c10681298442fbe39bb5be597d82fb91d1f11589ecc2284af0
+  newName: gcr.io/arokade-consumer/gcp-filestore-csi-driver
+  newTag: v2.0.0-dev

--- a/deploy/kubernetes/overlays/substrate/service.yaml
+++ b/deploy/kubernetes/overlays/substrate/service.yaml
@@ -2,13 +2,13 @@
 #
 # Key Features & Rationale:
 # 1. Selector: app=gcp-filestore-csi-driver, role=controller-plugin
-#    - Targets exclusively the controller deployment pod where the socat sidecar is running.
+#    - Targets exclusively the controller deployment pod where the envoy proxy is running.
 #    - Prevents gRPC traffic from load-balancing to node daemonset pods.
 #
-# 2. Port Mapping (port: 50053 -> targetPort: 10000)
-#    - Substrate ate-controller connects to port 50053 via cluster DNS:
-#      dns:///csi-filestore-controller.gcp-filestore-csi-driver.svc.cluster.local:50053
-#    - The service routes traffic to port 10000 where socat forwards it to /csi/csi.sock.
+# 2. Port Mapping (port: 10000 -> targetPort: 10000)
+#    - Substrate ate-api-server connects to port 10000 via cluster DNS:
+#      tcp://csi-filestore-controller.gcp-filestore-csi-driver.svc:10000
+#    - The service routes traffic to port 10000 where envoy forwards it to /csi/csi.sock.
 
 apiVersion: v1
 kind: Service
@@ -20,7 +20,7 @@ spec:
     app: gcp-filestore-csi-driver
     role: controller-plugin
   ports:
-  - name: grpc
-    port: 50053
+  - name: grpc-tls
+    port: 10000
     protocol: TCP
     targetPort: 10000


### PR DESCRIPTION
Replaces the insecure socat TCP tunneling with an Envoy proxy sidecar to enforce mutual TLS (mTLS) for Substrate's ate-api-server control plane.

Changes included:
* Replaced `socat` with `envoy:v1.34-latest` in controller patching.
* Attached projected Volume tokens (`podCertificate` & `clusterTrustBundle`) for native Substrate identity mapping.
* Provisioned `envoy_configmap.yaml` strictly asserting client SAN identity (`spiffe://cluster.local/ns/ate-system/sa/ate-api-server`).
* Updated `CSIDriverConfig` to enable TLS configuration and explicitly dial Envoy over TCP on port 10000.
* Updated `README.md` and inline comments to reflect the new proxy.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR upgrades the Substrate overlay architecture to fully secure the gRPC communication path between the Substrate API Server and the Filestore CSI Driver by introducing an Envoy sidecar proxy.

Previously, `socat` was used to bridge TCP to the internal CSI Unix Domain Socket. This upgrade drops `socat` in favor of an Envoy mTLS proxy, guaranteeing zero-trust identity authentication natively using Substrate `servicedns` and `podidentity` certificates. It ensures that only the authorized `ate-api-server` SPIFFE identity can invoke control-plane volume provisioning commands locally on the pod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
* **Testing Performed**: End-to-end `wget` tested using an external file via the dynamic Substrate VolumePool share on GKE. Verified `MountVolume.SetUp` securely loaded credential bundles natively into the controller without CrashLoopBackOffs.
* **Overrides Applied**: Note that this overlay currently includes overrides to point the `gcp-filestore-csi-driver` to the `v2.0.0-dev` image, and injects the `--filestore-service-endpoint=staging-file.sandbox.googleapis.com` execution argument to support sandbox VolumePool testing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update Substrate GKE overlay to enforce strict zero-trust mTLS via Envoy proxy sidecar.
```